### PR TITLE
Bugs/GitHub action helm release

### DIFF
--- a/.github/workflows/helm-release.yml
+++ b/.github/workflows/helm-release.yml
@@ -134,12 +134,3 @@ jobs:
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v2
-
-      # - name: Run chart-releaser
-      #   uses: helm/chart-releaser-action@v1.5.0
-      #   with:
-      #     mark_as_latest: ${{ github.event.inputs.mark_as_latest }}
-      #   env:
-      #     CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
-      #     CR_SKIP_EXISTING: true
-

--- a/.github/workflows/helm-release.yml
+++ b/.github/workflows/helm-release.yml
@@ -4,11 +4,23 @@ on:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
     inputs:
-      mark_as_latest:
+      release_tag:
+        type: string
+        description: "release tag that should be used for this release"
+        required: true
+        default: ""
+
+      overwrite_release_assets:
         type: boolean
-        description: "should release be marked as latest"
+        description: "Should Overwrite Release Assets"
         required: false
         default: false
+
+      prerelease:
+        type: boolean
+        description: "should this release be marked as pre-release"
+        required: false
+        default: true
 
 jobs:
   release:
@@ -31,6 +43,9 @@ jobs:
       - name: Install Helm
         uses: azure/setup-helm@v3
 
+      - name: Setup Pages
+        uses: actions/configure-pages@v3
+
       - name: Add repositories
         run: |
           for dir in $(ls -d charts/*); do
@@ -40,11 +55,74 @@ jobs:
             popd
           done
 
-      - name: Run chart-releaser
-        uses: helm/chart-releaser-action@v1.5.0
-        with:
-          mark_as_latest: ${{ github.event.inputs.mark_as_latest }}
+      - name: Releasing Helm Charts
         env:
-          CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
-          CR_SKIP_EXISTING: true
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+        shell: bash
+        run: |+
+          RELEASE_TAG=${{ github.event.inputs.release_tag }}
+          PRE_RELEASE=${{ github.event.inputs.prerelease }}
+          OVERWRITE_RELEASE_ASSETS=${{ github.event.inputs.overwrite_release_assets }}
+
+          RELEASE_TITLE="kloudlite-helm-charts"
+
+          opts=("-R" "$GITHUB_REPOSITORY")
+
+          len=$(gh release list ${opts[@]} | grep -i $RELEASE_TAG | awk -F\t '{print $3}' | wc -l)
+
+          if [[ $len -eq 0 ]]; then
+            createOpts=${opts[@]}
+            if $PRE_RELEASE; then
+              createOpts+=("--prerelease")
+            fi
+            if ! [[ -z $RELEASE_TITLE ]]; then
+              createOpts+=("--title" "$RELEASE_TITLE")
+            fi
+            createOpts+=("--notes" "'$RELEASE_NOTES'")
+
+            echo "creating github release with cmd: \`gh release create $RELEASE_TAG ${createOpts[@]}\` " 
+            eval gh release create $RELEASE_TAG ${createOpts[@]}
+          fi
+
+          tar_dir=".chart-releases"
+
+          for dir in $(ls -d charts/*); do
+            echo cr package $dir --package-path $tar_dir
+            cr package $dir --package-path $tar_dir
+          done
+
+          uploadOpts=${opts[@]}
+          if $OVERWRITE_RELEASE_ASSETS; then
+            uploadOpts+=("--clobber")
+          fi
+
+          echo "uploading packaged helm-charts with cmd: \`gh release upload $RELEASE_TAG ${uploadOpts[@]} $tar_dir/*.tgz\`" 
+          eval gh release upload $RELEASE_TAG ${uploadOpts[@]} $tar_dir/*.tgz
+
+          helm repo index $tar_dir --url https://github.com/$GITHUB_REPOSITORY/releases/download/$RELEASE_TAG
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v1
+        with:
+          name: github-pages
+          path: .chart-releases/index.yaml
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: release
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v2
+
+      # - name: Run chart-releaser
+      #   uses: helm/chart-releaser-action@v1.5.0
+      #   with:
+      #     mark_as_latest: ${{ github.event.inputs.mark_as_latest }}
+      #   env:
+      #     CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+      #     CR_SKIP_EXISTING: true
 

--- a/.github/workflows/helm-release.yml
+++ b/.github/workflows/helm-release.yml
@@ -79,11 +79,9 @@ jobs:
 
           opts=("-R" "$GITHUB_REPOSITORY")
 
-          len=$(gh release list ${opts[@]} | grep -i $RELEASE_TAG | awk -F\t '{print $3}' | wc -l)
+          release=$(gh release list ${opts[@]} | grep -i $RELEASE_TAG || echo "")
 
-          echo "len of github release list: $len"
-
-          if [[ $len -eq 0 ]]; then
+          if [[ -z $release ]]; then
             echo "going to create release, as it does not exist"
             createOpts=${opts[@]}
             if $PRE_RELEASE; then

--- a/.github/workflows/helm-release.yml
+++ b/.github/workflows/helm-release.yml
@@ -113,12 +113,15 @@ jobs:
           eval gh release upload $RELEASE_TAG ${uploadOpts[@]} $tar_dir/*.tgz
 
           helm repo index $tar_dir --url https://github.com/$GITHUB_REPOSITORY/releases/download/$RELEASE_TAG
+          mkdir -p .static-pages
+          cp $tar_dir/index.yaml .static-pages/index.yaml
+
 
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v1
         with:
           name: github-pages
-          path: .chart-releases/index.yaml
+          path: .static-pages
 
   deploy:
     environment:

--- a/.github/workflows/helm-release.yml
+++ b/.github/workflows/helm-release.yml
@@ -55,6 +55,14 @@ jobs:
             popd
           done
 
+      - name: Setting up Chart Releaser
+        run: |+
+          curl -L0 https://github.com/helm/chart-releaser/releases/download/v1.5.0/chart-releaser_1.5.0_linux_amd64.tar.gz > /tmp/chart-releaser.tar.gz && tar xf /tmp/chart-releaser.tar.gz -C /tmp && mv /tmp/cr /usr/local/bin/cr
+
+      - name: Installing Github Cli
+        run: |+
+          curl -L0 https://github.com/cli/cli/releases/download/v2.29.0/gh_2.29.0_linux_amd64.tar.gz > /tmp/gh_2.29.0_linux_amd64.tar.gz && tar xf /tmp/gh_2.29.0_linux_amd64.tar.gz -C /tmp && mv /tmp/gh_2.29.0_linux_amd64/bin/gh /usr/local/bin/gh
+
       - name: Releasing Helm Charts
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/helm-release.yml
+++ b/.github/workflows/helm-release.yml
@@ -22,12 +22,15 @@ on:
         required: false
         default: true
 
+permissions:
+  contents: write
+  id-token: write
+  pages: write
+
 jobs:
   release:
     # depending on default permission settings for your org (contents being read-only or read-write for workloads), you will have to add permissions
     # see: https://docs.github.com/en/actions/security-guides/automatic-token-authentication#modifying-the-permissions-for-the-github_token
-    permissions:
-      contents: write
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/helm-release.yml
+++ b/.github/workflows/helm-release.yml
@@ -70,7 +70,10 @@ jobs:
 
           len=$(gh release list ${opts[@]} | grep -i $RELEASE_TAG | awk -F\t '{print $3}' | wc -l)
 
+          echo "len of github release list: $len"
+
           if [[ $len -eq 0 ]]; then
+            echo "going to create release, as it does not exist"
             createOpts=${opts[@]}
             if $PRE_RELEASE; then
               createOpts+=("--prerelease")
@@ -83,6 +86,8 @@ jobs:
             echo "creating github release with cmd: \`gh release create $RELEASE_TAG ${createOpts[@]}\` " 
             eval gh release create $RELEASE_TAG ${createOpts[@]}
           fi
+
+          echo "release exists, going to build packages"
 
           tar_dir=".chart-releases"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,9 @@
 FROM golang:alpine
-RUN apk add bash git
+RUN apk add bash git curl
 WORKDIR /workspace
-RUN GOBIN=/usr/local/bin go install github.com/go-task/task/v3/cmd/task@latest
+ENV GOBIN=/usr/local/bin
+RUN go install github.com/go-task/task/v3/cmd/task@latest
+RUN curl -L0 https://github.com/helm/chart-releaser/releases/download/v1.5.0/chart-releaser_1.5.0_linux_amd64.tar.gz > /tmp/chart-releaser.tar.gz && tar xf /tmp/chart-releaser.tar.gz -C /tmp && mv /tmp/cr $GOBIN
 COPY Taskfile.yml ./Taskfile.yml
 COPY cmd ./cmd
 RUN task setup

--- a/charts/kloudlite-platform/Chart.lock
+++ b/charts/kloudlite-platform/Chart.lock
@@ -5,5 +5,5 @@ dependencies:
 - name: ingress-nginx
   repository: https://kubernetes.github.io/ingress-nginx
   version: 4.6.0
-digest: sha256:511bef08561a563a482ca6b470ec16b2ee176d92c58095ba889cfbeaba907856
-generated: "2023-04-29T13:37:45.133763056+05:30"
+digest: sha256:7a2e59c7ed2b0a3bcf80ba045bc552d5608444188b401d5ae1ce497a807d96df
+generated: "2023-05-29T16:09:00.79084799+05:30"

--- a/charts/kloudlite-platform/templates/apis/comms-api.yml.tpl
+++ b/charts/kloudlite-platform/templates/apis/comms-api.yml.tpl
@@ -12,7 +12,7 @@ spec:
 
   services:
     - port: {{.Values.apps.commsApi.configuration.grpcPort}}
-      targetPort: {{.values.apps.commsApi.configuration.grpcPort}}
+      targetPort: {{.Values.apps.commsApi.configuration.grpcPort}}
       name: grpc
       type: tcp
 
@@ -29,7 +29,7 @@ spec:
 
       env:
         - key: GRPC_PORT
-          value: {{.values.apps.commsApi.configuration.grpcPort | squote}}
+          value: {{.Values.apps.commsApi.configuration.grpcPort | squote}}
 
         - key: SUPPORT_EMAIL
           value: {{.Values.apps.commsApi.configuration.supportEmail}}

--- a/charts/kloudlite-platform/templates/apis/console-api.yml.tpl
+++ b/charts/kloudlite-platform/templates/apis/console-api.yml.tpl
@@ -90,7 +90,7 @@ spec:
           value: {{.Values.kafka.consumerGroupId}}
 
         - key: IAM_GRPC_ADDR
-          value: {{.Values.apps.iamApi.name}}.{{.Release.Namespace}}.svc.cluster.local:{{.values.apps.iamApi.configuration.grpcPort}}
+          value: {{.Values.apps.iamApi.name}}.{{.Release.Namespace}}.svc.cluster.local:{{.Values.apps.iamApi.configuration.grpcPort}}
 
         - key: DEFAULT_PROJECT_WORKSPACE_NAME
           value: {{.Values.defaultProjectWorkspaceName}}

--- a/charts/kloudlite-platform/templates/apis/container-registry-api.yml.tpl
+++ b/charts/kloudlite-platform/templates/apis/container-registry-api.yml.tpl
@@ -12,12 +12,12 @@ spec:
 
   services:
     - port: 80
-      targetPort: {{.values.apps.containerRegistryApi.configuration.httpPort}}
+      targetPort: {{.Values.apps.containerRegistryApi.configuration.httpPort}}
       name: http
       type: tcp
 
-    - port: {{.values.apps.containerRegistryApi.configuration.grpcPort}}
-      targetPort: {{.values.apps.containerRegistryApi.configuration.grpcPort}}
+    - port: {{.Values.apps.containerRegistryApi.configuration.grpcPort}}
+      targetPort: {{.Values.apps.containerRegistryApi.configuration.grpcPort}}
       name: grpc
       type: tcp
 

--- a/charts/kloudlite-platform/templates/operators/artifacts-harbor.yml.tpl
+++ b/charts/kloudlite-platform/templates/operators/artifacts-harbor.yml.tpl
@@ -11,13 +11,13 @@ metadata:
   name: {{$harborSecretName}}
   namespace: {{.Release.Namespace}}
 stringData:
-  API_VERSION: {{.Values.harbor.apiVersion}}
-  ADMIN_USERNAME: {{.Values.harbor.adminUsername}}
-  ADMIN_PASSWORD: {{.Values.harbor.adminPassword}}
-  IMAGE_REGISTRY_HOST: {{.Values.harbor.imageRegistryHost}}
-  WEBHOOK_ENDPOINT: {{.Values.harbor.webhookEndpoint}}
-  WEBHOOK_NAME: {{.Values.harbor.webhookName}}
-  WEBHOOK_AUTHZ: {{.Values.harbor.webhookAuthz}}
+  API_VERSION: {{.Values.operators.artifactsHarbor.configuration.harbor.apiVersion}}
+  ADMIN_USERNAME: {{.Values.operators.artifactsHarbor.configuration.harbor.adminUsername}}
+  ADMIN_PASSWORD: {{.Values.operators.artifactsHarbor.configuration.harbor.adminPassword}}
+  IMAGE_REGISTRY_HOST: {{.Values.operators.artifactsHarbor.configuration.harbor.imageRegistryHost}}
+  WEBHOOK_ENDPOINT: {{.Values.operators.artifactsHarbor.configuration.harbor.webhookEndpoint}}
+  WEBHOOK_NAME: {{.Values.operators.artifactsHarbor.configuration.harbor.webhookName}}
+  WEBHOOK_AUTHZ: {{.Values.operators.artifactsHarbor.configuration.harbor.webhookAuthz}}
   {{/* SERVICE_ACCOUNT: {{.Values.harbor.serviceAccount}} */}}
 
 ---

--- a/charts/kloudlite-platform/templates/secrets/oauth-secrets.yml.tpl
+++ b/charts/kloudlite-platform/templates/secrets/oauth-secrets.yml.tpl
@@ -36,7 +36,7 @@ stringData:
   GITLAB_SCOPES: "api,read_repository"
   {{- end }}
 
-  {{- if .Values.apps.authApi.configuration.oAuth2.gitlab.enabled }}
+  {{- if .Values.apps.authApi.configuration.oAuth2.google.enabled }}
   GOOGLE_CALLBACK_URL: {{ .Values.apps.authApi.configuration.oAuth2.google.callbackUrl }}
   GOOGLE_CLIENT_ID: {{.Values.apps.authApi.configuration.oAuth2.google.clientId |squote}}
   GOOGLE_CLIENT_SECRET: {{.Values.apps.authApi.configuration.oAuth2.google.clientSecret}}
@@ -44,4 +44,4 @@ stringData:
   {{- end }}
 ---
 
-${{- end }}
+{{- end }}


### PR DESCRIPTION
## Description

CI/CD Updates:
  - replacing [helm/chart-releaser-action](https://github.com/helm/chart-releaser-action), with our own chart releaser shell snippets
  - Abandoning using helm repo via `gh-pages`, as prescribed by chart-releaser, with our own actions to host index.yaml for chart listing directly (with actions artifacts) without having any git branches specifically for github pages
