### PR TITLE
Bug/omit container registry api from gateway supergraph

### DIFF
--- a/charts/kloudlite-platform/README.md
+++ b/charts/kloudlite-platform/README.md
@@ -159,17 +159,19 @@ helm show values kloudlite/kloudlite-platform
 | clusterIssuer.cloudflareWildCardCert.cloudflareCreds | object | `{"email":"<cloudflare-email>","secretToken":"<cloudflare-secret-token>"}` | cloudflare authz credentials |
 | clusterIssuer.cloudflareWildCardCert.cloudflareCreds.email | string | `"<cloudflare-email>"` | cloudflare authorized email |
 | clusterIssuer.cloudflareWildCardCert.cloudflareCreds.secretToken | string | `"<cloudflare-secret-token>"` | cloudflare authorized secret token |
-| clusterIssuer.cloudflareWildCardCert.create | bool | `true` |  |
+| clusterIssuer.cloudflareWildCardCert.create | bool | `false` |  |
 | clusterIssuer.cloudflareWildCardCert.domains | list | `["*.dev.kloudlite.io"]` | list of all SANs (Subject Alternative Names) for which wildcard certs should be created |
 | clusterIssuer.cloudflareWildCardCert.name | string | `"kl-cert-wildcard"` | name for wildcard cert |
 | clusterIssuer.cloudflareWildCardCert.secretName | string | `"kl-cert-wildcard-tls"` | k8s secret where wildcard cert should be stored |
-| clusterIssuer.create | bool | `true` |  |
+| clusterIssuer.install | bool | `true` | whether to install cluster issuer |
 | clusterIssuer.name | string | `"cluster-issuer"` | name of cluster issuer, to be used for issuing wildcard cert |
 | clusterSvcAccount | string | `"kloudlite-cluster-svc-account"` | service account for privileged k8s operations, like creating namespaces, apps, routers etc. |
 | cookieDomain | string | `".kloudlite.io"` | cookie domain dictates at what domain, the cookies should be set for auth or other purposes |
 | defaultProjectWorkspaceName | string | `"default"` | default project workspace name, that should be auto created, whenever you create a project |
 | imagePullPolicy | string | `"Always"` | image pull policies for kloudlite pods, belonging to this chartvalues |
-| ingress-nginx | object | `{"controller":{"admissionWebhooks":{"enabled":false,"failurePolicy":"Ignore"},"electionID":"ingress-nginx","extraArgs":{"default-ssl-certificate":"kl-init-operators/kl-cert-wildcard-tls"},"ingressClass":"ingress-nginx","ingressClassByName":true,"ingressClassResource":{"controllerValue":"k8s.io/ingress-nginx","enabled":true,"name":"ingress-nginx"},"kind":"Deployment","podLabels":{},"resources":{"requests":{"cpu":"100m","memory":"200Mi"}},"service":{"type":"LoadBalancer"},"watchIngressWithoutClass":false},"create":true,"nameOverride":"ingress-nginx","rbac":{"create":false},"serviceAccount":{"create":false,"name":"kloudlite-cluster-svc-account"}}` | ingress nginx configurations, read more at https://kubernetes.github.io/ingress-nginx/ |
+| ingress-nginx | object | `{"controller":{"admissionWebhooks":{"enabled":false,"failurePolicy":"Ignore"},"electionID":"ingress-nginx","ingressClass":"ingress-nginx","ingressClassByName":true,"ingressClassResource":{"controllerValue":"k8s.io/ingress-nginx","enabled":true,"name":"ingress-nginx"},"kind":"Deployment","podLabels":{},"resources":{"requests":{"cpu":"100m","memory":"200Mi"}},"service":{"type":"LoadBalancer"},"watchIngressWithoutClass":false},"install":true,"nameOverride":"ingress-nginx","rbac":{"create":false},"serviceAccount":{"create":false,"name":"kloudlite-cluster-svc-account"}}` | ingress nginx configurations, read more at https://kubernetes.github.io/ingress-nginx/ |
+| ingress-nginx.controller.kind | string | `"Deployment"` | ingress nginx controller configuration |
+| ingress-nginx.install | bool | `true` | whether to install ingress-nginx |
 | ingressClassName | string | `"ingress-nginx"` | ingress class name that should be used for all the ingresses, created by this chart |
 | kafka.consumerGroupId | string | `"control-plane"` | consumer group ID for kafka consumers running with this helm chart |
 | kafka.topicBYOCClientUpdates | string | `"kl-byoc-client-updates"` | kafka topic for messages where target clusters sends updates for cluster BYOC resource |

--- a/charts/kloudlite-platform/Taskfile.yml
+++ b/charts/kloudlite-platform/Taskfile.yml
@@ -36,6 +36,8 @@ tasks:
       NormalSvcAccount: kloudlite-svc-account
 
       IngressClassName: ingress-nginx
+
+      WildcardCertEnabled: false
       WildcardCertName: kl-cert-wildcard
       CloudflareEmail: '<cloudflare-email>'
       CloudflareSecretToken: '<cloudflare-secret-token>'

--- a/charts/kloudlite-platform/templates/apis/gateway-api.yml.tpl
+++ b/charts/kloudlite-platform/templates/apis/gateway-api.yml.tpl
@@ -63,8 +63,10 @@ data:
       - name: {{.Values.apps.authApi.name}}
         url: http://{{.Values.apps.authApi.name}}.{{.Release.Namespace}}.svc.cluster.local/query
 
+      {{- if .Values.apps.containerRegistryApi.enabled }}
       - name: {{.Values.apps.containerRegistryApi.name}}
         url: http://{{.Values.apps.containerRegistryApi.name}}.{{.Release.Namespace}}.svc.cluster.local/query
+      {{- end }}
 
       - name: {{.Values.apps.consoleApi.name}}
         url: http://{{.Values.apps.consoleApi.name}}.{{.Release.Namespace}}.svc.cluster.local/query

--- a/charts/kloudlite-platform/templates/apis/message-office-api.yml.tpl
+++ b/charts/kloudlite-platform/templates/apis/message-office-api.yml.tpl
@@ -3,8 +3,6 @@ kind: App
 metadata:
   name: {{.Values.apps.messageOfficeApi.name}}
   namespace: {{.Release.Namespace}}
-  annotations:
-    
 spec:
   region: {{.Values.region | default ""}}
   {{/* serviceAccount: {{.Values.normalSvcAccount}} */}}

--- a/charts/kloudlite-platform/templates/apis/webhooks-api.yml.tpl
+++ b/charts/kloudlite-platform/templates/apis/webhooks-api.yml.tpl
@@ -5,8 +5,6 @@ kind: App
 metadata:
   name: {{.Values.apps.webhooksApi.name}}
   namespace: {{.Release.Namespace}}
-  annotations:
-    kloudlite.io/account-ref: {{.Values.accountName}}
 spec:
   region: {{.Values.region | default ""}}
   serviceAccount: {{.Values.normalSvcAccount}}

--- a/charts/kloudlite-platform/values.yaml
+++ b/charts/kloudlite-platform/values.yaml
@@ -146,7 +146,8 @@ ingressClassName: ingress-nginx
 
 # -- ingress nginx configurations, read more at https://kubernetes.github.io/ingress-nginx/
 ingress-nginx:
-  create: true
+  # -- whether to install ingress-nginx
+  install: true
 
   nameOverride: ingress-nginx
 
@@ -158,9 +159,26 @@ ingress-nginx:
     name: kloudlite-cluster-svc-account
 
   controller:
+    # -- ingress nginx controller configuration
     kind: Deployment
     service:
       type: LoadBalancer
+
+    # if you want to install as Daemonset, uncomment the following, and commment the above block
+
+    # kind: DaemonSet
+    # service:
+    #   type: "ClusterIP"
+    #
+    # hostNetwork: true
+    # hostPort:
+    #   enabled: true
+    #   ports:
+    #     http: 80
+    #     https: 443
+    #     healthz: 10254
+    #
+    # dnsPolicy: ClusterFirstWithHostNet
     
 
     watchIngressWithoutClass: false
@@ -171,9 +189,6 @@ ingress-nginx:
       enabled: true
       name: ingress-nginx
       controllerValue: "k8s.io/ingress-nginx"
-
-    extraArgs:
-      default-ssl-certificate: "kl-init-operators/kl-cert-wildcard-tls"
 
     podLabels: *podLabels
 
@@ -186,19 +201,20 @@ ingress-nginx:
       enabled: false
       failurePolicy: Ignore
 
-
 # -- namespace where chart kloudlite-operators have been installed
 operatorsNamespace: kl-init-operators
 
 clusterIssuer:
-  create: true
+  # -- whether to install cluster issuer
+  install: true
+
   # -- name of cluster issuer, to be used for issuing wildcard cert
   name: "cluster-issuer"
   # -- email that should be used for communicating with letsencrypt services
   acmeEmail: sample@example.com
 
   cloudflareWildCardCert:
-    create: true
+    create: false
 
     # -- name for wildcard cert
     name: kl-cert-wildcard


### PR DESCRIPTION
## Description

+ conditionally omits container-registry api from the gateway supergraph
+ conditionally omits wildcard-ssl-args from ingress-nginx controller, when wild-card-cert is disabled
+ provides commented snippet for ingress-nginx controller to be installed using Deployment or DaemonSet
