### PR TITLE
[workflow] helm releaser workflow fix

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,20 +1,20 @@
 ---
 name: Feature Request
 about: Suggest an idea for this project
-title: '[FEATURE]'
+title: '[FEATURE] '
 labels: 'enhancement'
 assignees: ''
 
 ---
 
-**Is your feature request related to a problem? Please describe.**
+## Is your feature request related to a problem? Please describe.
 A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
 
-**Describe the solution you'd like**
+## Describe the solution you'd like
 A clear and concise description of what you want to happen.
 
-**Describe alternatives you've considered**
+## Describe alternatives you've considered
 A clear and concise description of any alternative solutions or features you've considered.
 
-**Additional context**
+## Additional context
 Add any other context or screenshots about the feature request here.

--- a/.github/workflows/helm-release.yml
+++ b/.github/workflows/helm-release.yml
@@ -131,16 +131,9 @@ jobs:
             cr package $dir --package-path $tar_dir
           done
 
-          uploadOpts=${opts[@]}
-          if $OVERWRITE_RELEASE_ASSETS; then
-            uploadOpts+=("--clobber")
-          fi
-
-          echo "uploading packaged helm-charts with cmd: \`gh release upload $RELEASE_TAG ${uploadOpts[@]} $tar_dir/*.tgz\`" 
-          eval gh release upload $RELEASE_TAG ${uploadOpts[@]} $tar_dir/*.tgz
-
           # remove entries related to the current release_tag, for all the charts
           curl -f -L0 https://${{github.actor}}.github.io/${{github.event.repository.name}}/index.yaml > $tar_dir/index.yaml
+          cat $tar_dir/index.yaml
 
           for dir in $(ls -d charts); do
             export CHART_NAME=$dir
@@ -148,6 +141,15 @@ jobs:
             cat $tar_dir/index.yaml | yq '. | .entries[env.CHART_NAME] = (.entries[env.CHART_NAME] | map_values(select(.appVersion != env.RELEASE_TAG)))' -y | tee /tmp/index2.yaml
             mv /tmp/index2.yaml $tar_dir/index.yaml
           done
+
+
+          uploadOpts=${opts[@]}
+          if $OVERWRITE_RELEASE_ASSETS; then
+            uploadOpts+=("--clobber")
+          fi
+
+          echo "uploading packaged helm-charts with cmd: \`gh release upload $RELEASE_TAG ${uploadOpts[@]} $tar_dir/*.tgz\`" 
+          eval gh release upload $RELEASE_TAG ${uploadOpts[@]} $tar_dir/*.tgz
 
           helm repo index $tar_dir --url https://github.com/$GITHUB_REPOSITORY/releases/download/$RELEASE_TAG --merge
           mkdir -p .static-pages

--- a/.github/workflows/helm-release.yml
+++ b/.github/workflows/helm-release.yml
@@ -131,18 +131,6 @@ jobs:
             cr package $dir --package-path $tar_dir
           done
 
-          # remove entries related to the current release_tag, for all the charts
-          curl -f -L0 https://${{github.actor}}.github.io/${{github.event.repository.name}}/index.yaml > $tar_dir/index.yaml
-          cat $tar_dir/index.yaml
-
-          for dir in $(ls -d charts/*); do
-            export CHART_NAME=$(basename $dir)
-            
-            cat $tar_dir/index.yaml | yq '. | .entries[env.CHART_NAME] = (.entries[env.CHART_NAME] | map_values(select(.appVersion != env.RELEASE_TAG)))' -y | tee /tmp/index2.yaml
-            mv /tmp/index2.yaml $tar_dir/index.yaml
-          done
-
-
           uploadOpts=${opts[@]}
           if $OVERWRITE_RELEASE_ASSETS; then
             uploadOpts+=("--clobber")
@@ -151,7 +139,19 @@ jobs:
           echo "uploading packaged helm-charts with cmd: \`gh release upload $RELEASE_TAG ${uploadOpts[@]} $tar_dir/*.tgz\`" 
           eval gh release upload $RELEASE_TAG ${uploadOpts[@]} $tar_dir/*.tgz
 
-          helm repo index $tar_dir --url https://github.com/$GITHUB_REPOSITORY/releases/download/$RELEASE_TAG --merge
+          # remove entries related to the current release_tag, for all the charts
+          curl -f -L0 https://${{github.actor}}.github.io/${{github.event.repository.name}}/index.yaml > $tar_dir/index.yaml
+          cat $tar_dir/index.yaml
+
+          for dir in $(ls -d charts/*); do
+            export CHART_NAME=$(basename $dir)
+            
+            cat $tar_dir/index.yaml | yq '. | .entries[env.CHART_NAME] = (.entries[env.CHART_NAME] | map_values(select(.appVersion != env.RELEASE_TAG)))' -y | tee /tmp/index2.yaml
+
+            mv /tmp/index2.yaml $tar_dir/index.yaml
+          done
+
+          helm repo index $tar_dir --url https://github.com/$GITHUB_REPOSITORY/releases/download/$RELEASE_TAG --merge $tar_dir/index.yaml
           mkdir -p .static-pages
           cp $tar_dir/index.yaml .static-pages/index.yaml
 

--- a/.github/workflows/helm-release.yml
+++ b/.github/workflows/helm-release.yml
@@ -144,7 +144,8 @@ jobs:
 
           for dir in $(ls -d charts); do
             export CHART_NAME=$dir
-            cat $tar_dir/index.yaml | yq '.entries[env.CHART_NAME][] | select(.appVersion != env.RELEASE_TAG)' -y | tee /tmp/index2.yaml
+            
+            cat $tar_dir/index.yaml | yq '. | .entries[env.CHART_NAME] = (.entries[env.CHART_NAME] | map_values(select(.appVersion != env.RELEASE_TAG)))' -y | tee /tmp/index2.yaml
             mv /tmp/index2.yaml $tar_dir/index.yaml
           done
 

--- a/.github/workflows/helm-release.yml
+++ b/.github/workflows/helm-release.yml
@@ -135,8 +135,8 @@ jobs:
           curl -f -L0 https://${{github.actor}}.github.io/${{github.event.repository.name}}/index.yaml > $tar_dir/index.yaml
           cat $tar_dir/index.yaml
 
-          for dir in $(ls -d charts); do
-            export CHART_NAME=$dir
+          for dir in $(ls -d charts/*); do
+            export CHART_NAME=$(basename $dir)
             
             cat $tar_dir/index.yaml | yq '. | .entries[env.CHART_NAME] = (.entries[env.CHART_NAME] | map_values(select(.appVersion != env.RELEASE_TAG)))' -y | tee /tmp/index2.yaml
             mv /tmp/index2.yaml $tar_dir/index.yaml

--- a/.github/workflows/helm-release.yml
+++ b/.github/workflows/helm-release.yml
@@ -79,9 +79,8 @@ jobs:
 
           opts=("-R" "$GITHUB_REPOSITORY")
 
-          echo "here 1"
           release=$(gh release list ${opts[@]} | tail -n +1 | (grep -iE "\s+$RELEASE_TAG\s+" || echo -n "") | awk '{print $3}')
-          echo "here2 , release: $release"
+          echo "release $release exists, going to build charts, now"
 
           if [[ -z $release ]]; then
             echo "going to create release, as RELEASE ($RELEASE_TAG) does not exist"
@@ -95,10 +94,8 @@ jobs:
             createOpts+=("--notes" "'$RELEASE_NOTES'")
 
             echo "creating github release with cmd: \`gh release create $RELEASE_TAG ${createOpts[@]}\` " 
-            eval gh release create $RELEASE_TAG ${createOpts[@]}
+            eval gh release create $RELEASE_TAG ${createOpts[@]} --generate-notes
           fi
-
-          echo "release exists, going to build packages"
 
           tar_dir=".chart-releases"
 

--- a/.github/workflows/helm-release.yml
+++ b/.github/workflows/helm-release.yml
@@ -49,6 +49,15 @@ jobs:
       - name: Setup Pages
         uses: actions/configure-pages@v3
 
+      - uses: actions/setup-python@v4
+        with:
+          python-version: 3.9
+
+      - name: Run image
+        uses: CfirTsabari/actions-pipx@v1
+        run: |+
+          pipx install xq
+
       - name: Add repositories
         run: |
           for dir in $(ls -d charts/*); do
@@ -66,11 +75,27 @@ jobs:
         run: |+
           curl -L0 https://github.com/cli/cli/releases/download/v2.29.0/gh_2.29.0_linux_amd64.tar.gz > /tmp/gh_2.29.0_linux_amd64.tar.gz && tar xf /tmp/gh_2.29.0_linux_amd64.tar.gz -C /tmp && mv /tmp/gh_2.29.0_linux_amd64/bin/gh /usr/local/bin/gh
 
+      - name: Installing Github Cli
+        run: |+
+          curl -L0 https://github.com/cli/cli/releases/download/v2.29.0/gh_2.29.0_linux_amd64.tar.gz > /tmp/gh_2.29.0_linux_amd64.tar.gz && tar xf /tmp/gh_2.29.0_linux_amd64.tar.gz -C /tmp && mv /tmp/gh_2.29.0_linux_amd64/bin/gh /usr/local/bin/gh
+
+      - name: update version and appVersion in charts' Chart.yaml
+        run: |+
+          RELEASE_TAG=${{ github.event.inputs.release_tag }}
+          for dir in $(ls -d charts/*); do
+            pushd $dir
+            sed -i "s/^version:.*/version: $RELEASE_TAG/g" Chart.yaml
+            sed -i "s/^appVersion:.*/appVersion: $RELEASE_TAG/g" Chart.yaml
+            popd
+          done
+
       - name: Releasing Helm Charts
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         shell: bash
         run: |+
+          set -o allexport
+
           RELEASE_TAG=${{ github.event.inputs.release_tag }}
           PRE_RELEASE=${{ github.event.inputs.prerelease }}
           OVERWRITE_RELEASE_ASSETS=${{ github.event.inputs.overwrite_existing_release_assets_if_applicable }}
@@ -80,8 +105,6 @@ jobs:
           opts=("-R" "$GITHUB_REPOSITORY")
 
           release=$(gh release list ${opts[@]} | tail -n +1 | (grep -iE "\s+$RELEASE_TAG\s+" || echo -n "") | awk '{print $3}')
-          echo "release $release exists, going to build charts, now"
-
           if [[ -z $release ]]; then
             echo "going to create release, as RELEASE ($RELEASE_TAG) does not exist"
             createOpts=${opts[@]}
@@ -95,6 +118,8 @@ jobs:
 
             echo "creating github release with cmd: \`gh release create $RELEASE_TAG ${createOpts[@]}\` " 
             eval gh release create $RELEASE_TAG ${createOpts[@]} --generate-notes
+          else
+            echo "release $release exists, going to build charts, now"
           fi
 
           tar_dir=".chart-releases"
@@ -112,7 +137,16 @@ jobs:
           echo "uploading packaged helm-charts with cmd: \`gh release upload $RELEASE_TAG ${uploadOpts[@]} $tar_dir/*.tgz\`" 
           eval gh release upload $RELEASE_TAG ${uploadOpts[@]} $tar_dir/*.tgz
 
-          helm repo index $tar_dir --url https://github.com/$GITHUB_REPOSITORY/releases/download/$RELEASE_TAG
+          # remove entries related to the current release_tag, for all the charts
+          curl -f -L0 https://${{github.actor}}.github.io/${{github.event.repository.name}}/index.yaml > $tar_dir/index.yaml
+
+          for dir in $(ls -d charts); do
+            export CHART_NAME=$dir
+            cat $tar_dir/index.yaml | yq '.entries[env.CHART_NAME][] | select(.appVersion != env.RELEASE_TAG)' | tee /tmp/index2.yaml
+            mv /tmp/index2.yaml $tar_dir/index.yaml
+          done
+
+          helm repo index $tar_dir --url https://github.com/$GITHUB_REPOSITORY/releases/download/$RELEASE_TAG --merge
           mkdir -p .static-pages
           cp $tar_dir/index.yaml .static-pages/index.yaml
 

--- a/.github/workflows/helm-release.yml
+++ b/.github/workflows/helm-release.yml
@@ -80,7 +80,7 @@ jobs:
           opts=("-R" "$GITHUB_REPOSITORY")
 
           echo "here 1"
-          echo "getting release by running \`gh release list ${opts[@]} | tail -n +1 | grep -iE "\b$RELEASE_TAG\b" | echo -n ""\` "
+          echo "getting release by running \`gh release list ${opts[@]} | tail -n +1 | grep -iE '\b$RELEASE_TAG\b' | echo -n ''\`"
           release=$(gh release list ${opts[@]} | tail -n +1 | grep -iE "\b$RELEASE_TAG\b" | echo -n "")
           echo "here2 , release: $release"
 

--- a/.github/workflows/helm-release.yml
+++ b/.github/workflows/helm-release.yml
@@ -80,8 +80,7 @@ jobs:
           opts=("-R" "$GITHUB_REPOSITORY")
 
           echo "here 1"
-          echo "getting release by running \`gh release list ${opts[@]} | tail -n +1 | grep -iE '\b$RELEASE_TAG\b' | echo -n ''\`"
-          release=$(gh release list ${opts[@]} | tail -n +1 | grep -iE "\b$RELEASE_TAG\b" | echo -n "")
+          release=$(gh release list ${opts[@]} | tail -n +1 | (grep -iE "\\b$RELEASE_TAG\\b" || echo -n "") | awk '{print $3}')
           echo "here2 , release: $release"
 
           if [[ -z $release ]]; then

--- a/.github/workflows/helm-release.yml
+++ b/.github/workflows/helm-release.yml
@@ -80,6 +80,7 @@ jobs:
           opts=("-R" "$GITHUB_REPOSITORY")
 
           echo "here 1"
+          echo "getting release by running \`gh release list ${opts[@]} | awk -F'\t' -v TAG=\"$RELEASE_TAG\" '{print ($3 == TAG) ? TAG: \"false\"}' | grep -i $RELEASE_TAG | echo -n \"\"\` "
           release=$(gh release list ${opts[@]} | awk -F'\t' -v TAG="$RELEASE_TAG" '{print ($3 == TAG) ? TAG: "false"}' | grep -i $RELEASE_TAG | echo -n "")
           echo "here2 , release: $release"
 

--- a/.github/workflows/helm-release.yml
+++ b/.github/workflows/helm-release.yml
@@ -53,12 +53,12 @@ jobs:
         with:
           python-version: 3.9
 
-      - name: Run image
+      - name: Setup pipx
         uses: CfirTsabari/actions-pipx@v1
 
       - name: Installing yq (with pipx)
         run: |+
-          pipx install xq
+          pipx install yq
 
       - name: Add repositories
         run: |
@@ -144,7 +144,7 @@ jobs:
 
           for dir in $(ls -d charts); do
             export CHART_NAME=$dir
-            cat $tar_dir/index.yaml | yq '.entries[env.CHART_NAME][] | select(.appVersion != env.RELEASE_TAG)' | tee /tmp/index2.yaml
+            cat $tar_dir/index.yaml | yq '.entries[env.CHART_NAME][] | select(.appVersion != env.RELEASE_TAG)' -y | tee /tmp/index2.yaml
             mv /tmp/index2.yaml $tar_dir/index.yaml
           done
 

--- a/.github/workflows/helm-release.yml
+++ b/.github/workflows/helm-release.yml
@@ -55,6 +55,8 @@ jobs:
 
       - name: Run image
         uses: CfirTsabari/actions-pipx@v1
+
+      - name: Installing yq (with pipx)
         run: |+
           pipx install xq
 

--- a/.github/workflows/helm-release.yml
+++ b/.github/workflows/helm-release.yml
@@ -8,11 +8,11 @@ on:
         type: string
         description: "release tag that should be used for this release"
         required: true
-        default: ""
+        default: "${{ github.ref }}"
 
-      overwrite_release_assets:
+      overwrite_existing_release_assets_if_applicable:
         type: boolean
-        description: "Should Overwrite Release Assets"
+        description: "Should Overwrite Existing Release Assets, if applicable"
         required: false
         default: false
 
@@ -73,7 +73,7 @@ jobs:
         run: |+
           RELEASE_TAG=${{ github.event.inputs.release_tag }}
           PRE_RELEASE=${{ github.event.inputs.prerelease }}
-          OVERWRITE_RELEASE_ASSETS=${{ github.event.inputs.overwrite_release_assets }}
+          OVERWRITE_RELEASE_ASSETS=${{ github.event.inputs.overwrite_existing_release_assets_if_applicable }}
 
           RELEASE_TITLE="kloudlite-helm-charts"
 
@@ -82,7 +82,7 @@ jobs:
           release=$(gh release list ${opts[@]} | awk -F'\t' -v RELEASE_TAG="$RELEASE_TAG" '{print ($3 == RELEASE_TAG) ? RELEASE_TAG: "false"}' | grep -i $RELEASE_TAG)
 
           if [[ -z $release ]]; then
-            echo "going to create release, as it does not exist"
+            echo "going to create release, as RELEASE ($RELEASE_TAG) does not exist"
             createOpts=${opts[@]}
             if $PRE_RELEASE; then
               createOpts+=("--prerelease")

--- a/.github/workflows/helm-release.yml
+++ b/.github/workflows/helm-release.yml
@@ -80,7 +80,7 @@ jobs:
           opts=("-R" "$GITHUB_REPOSITORY")
 
           echo "here 1"
-          release=$(gh release list ${opts[@]} | awk -F'\t' -v RELEASE_TAG="$RELEASE_TAG" '{print ($3 == RELEASE_TAG) ? RELEASE_TAG: "false"}' | grep -i $RELEASE_TAG)
+          release=$(gh release list ${opts[@]} | awk -F'\t' -v TAG="$RELEASE_TAG" '{print ($3 == TAG) ? TAG: "false"}' | grep -i $RELEASE_TAG | echo -n "")
           echo "here2 , release: $release"
 
           if [[ -z $release ]]; then

--- a/.github/workflows/helm-release.yml
+++ b/.github/workflows/helm-release.yml
@@ -8,7 +8,7 @@ on:
         type: string
         description: "release tag that should be used for this release"
         required: true
-        default: "${{ github.ref }}"
+        default: "1.0.5-nightly"
 
       overwrite_existing_release_assets_if_applicable:
         type: boolean

--- a/.github/workflows/helm-release.yml
+++ b/.github/workflows/helm-release.yml
@@ -79,7 +79,9 @@ jobs:
 
           opts=("-R" "$GITHUB_REPOSITORY")
 
+          echo "here 1"
           release=$(gh release list ${opts[@]} | awk -F'\t' -v RELEASE_TAG="$RELEASE_TAG" '{print ($3 == RELEASE_TAG) ? RELEASE_TAG: "false"}' | grep -i $RELEASE_TAG)
+          echo "here2 , release: $release"
 
           if [[ -z $release ]]; then
             echo "going to create release, as RELEASE ($RELEASE_TAG) does not exist"

--- a/.github/workflows/helm-release.yml
+++ b/.github/workflows/helm-release.yml
@@ -80,7 +80,7 @@ jobs:
           opts=("-R" "$GITHUB_REPOSITORY")
 
           echo "here 1"
-          release=$(gh release list ${opts[@]} | tail -n +1 | (grep -iE "\\b$RELEASE_TAG\\b" || echo -n "") | awk '{print $3}')
+          release=$(gh release list ${opts[@]} | tail -n +1 | (grep -iE "\s+$RELEASE_TAG\s+" || echo -n "") | awk '{print $3}')
           echo "here2 , release: $release"
 
           if [[ -z $release ]]; then

--- a/.github/workflows/helm-release.yml
+++ b/.github/workflows/helm-release.yml
@@ -80,8 +80,8 @@ jobs:
           opts=("-R" "$GITHUB_REPOSITORY")
 
           echo "here 1"
-          echo "getting release by running \`gh release list ${opts[@]} | awk -F'\t' -v TAG=\"$RELEASE_TAG\" '{print ($3 == TAG) ? TAG: \"false\"}' | grep -i $RELEASE_TAG | echo -n \"\"\` "
-          release=$(gh release list ${opts[@]} | awk -F'\t' -v TAG="$RELEASE_TAG" '{print ($3 == TAG) ? TAG: "false"}' | grep -i $RELEASE_TAG | echo -n "")
+          echo "getting release by running \`gh release list ${opts[@]} | tail -n +1 | grep -iE "\b$RELEASE_TAG\b" | echo -n ""\` "
+          release=$(gh release list ${opts[@]} | tail -n +1 | grep -iE "\b$RELEASE_TAG\b" | echo -n "")
           echo "here2 , release: $release"
 
           if [[ -z $release ]]; then

--- a/.github/workflows/readme-generator.yml
+++ b/.github/workflows/readme-generator.yml
@@ -1,5 +1,9 @@
 name: Readme Generator
-on: push
+on:
+  pull_request:
+    types:
+      - opened
+      - synchronize
 
 jobs:
   generate-readmes:

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -28,6 +28,7 @@ tasks:
       - |+
         pushd cmd/tmpl
         go build -o {{.TMPL}} -ldflags="-s -w -X 'main.Version={{.Version}}'" -buildvcs=false .
+        chmod +x {{.TMPL}}
         popd
 
   install:schelm:
@@ -39,6 +40,7 @@ tasks:
         if ! [[ -f "{{.SCHELM}}" ]] then
           go install github.com/databus23/schelm@master
         fi
+        chmod +x {{.SCHELM}}
 
   install:chart-doc-gen:
     silent: true
@@ -59,9 +61,8 @@ tasks:
         if ! [[ -f {{.HELM_DOCS}} ]] then
           go install github.com/norwoodj/helm-docs/cmd/helm-docs@v1.11.0
         fi
+        chmod +x {{.HELM_DOCS}}
 
-  generate-chart-docs:
-    cmds:
       # - docker run --rm --volume "$(pwd):/helm-docs" -u $(id -u) jnorwood/helm-docs:latest
       - |+
         {{.HELM_DOCS}}
@@ -72,4 +73,28 @@ tasks:
       - task: install:schelm
       # - task: install:chart-doc-gen
       - task: install:helm-docs
+
+  crds:
+    vars:
+      OutputDir: "/tmp/crds"
+      OperatorDir: "../operator"
+      HelmOperatorDir: "../helm-operator"
+      RedpandaVersion: v22.1.6
+    cmds:
+      - |+
+        mkdir -p {{.OutputDir}}
+
+        pushd {{.OperatorDir}} 2>&1 > /dev/null
+        task yaml:crds > {{.OutputDir}}/operator-crds.yml
+        popd 2>&1 > /dev/null
+
+        pushd {{.HelmOperatorDir}} 2>&1 >/dev/null
+        task yaml:crds > {{.OutputDir}}/helm-operator-crds.yml
+        popd 2>&1 > /dev/null
+
+        # cert manager CRDs
+        curl -L0 https://github.com/cert-manager/cert-manager/releases/download/v1.12.0/cert-manager.crds.yaml > {{.OutputDir}}/cert-manager-crds.yml
+
+        # redpanda CRDs
+        curl -L0 https://raw.githubusercontent.com/redpanda-data/redpanda/{{.RedpandaVersion}}/src/go/k8s/config/crd/bases/redpanda.vectorized.io_clusters.yaml > {{.OutputDir}}/redpanda-crds.yml
 

--- a/charts/kloudlite-agent/README.md
+++ b/charts/kloudlite-agent/README.md
@@ -94,4 +94,4 @@ helm show values kloudlite/kloudlite-agent
 | operators.wgOperator.configuration.svcCidr | string | `"10.43.0.0/16"` | cluster services CIDR range |
 | operators.wgOperator.enabled | bool | `true` | whether to enable wg operator |
 | operators.wgOperator.image | string | `"ghcr.io/kloudlite/agent/operator/wg:v1.0.5-nightly"` | wg operator image and tag |
-| svcAccountName | string | `"kloudlite-cluster-svc-account"` | k8s service account name, which all the pods installed by this chart uses |
+| svcAccountName | string | `"cluster-svc-account"` | k8s service account name, which all the pods installed by this chart uses |

--- a/charts/kloudlite-agent/Taskfile.yml
+++ b/charts/kloudlite-agent/Taskfile.yml
@@ -31,7 +31,7 @@ tasks:
 
       DefaultImagePullSecretName: "kl-image-pull-creds"
 
-      ClusterSvcAccountName: kloudlite-cluster-svc-account
+      ClusterSvcAccountName: cluster-svc-account
 
       MessageOfficeGRPCAddr: message-office-api.dev.kloudlite.io:443
 

--- a/charts/kloudlite-agent/templates/_helpers.tpl
+++ b/charts/kloudlite-agent/templates/_helpers.tpl
@@ -1,7 +1,7 @@
 {{/*
 Expand the name of the chart.
 */}}
-{{- define "kloudlite-operators.name" -}}
+{{- define "kloudlite-agent.name" -}}
 {{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
 {{- end }}
 
@@ -10,7 +10,7 @@ Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 If release name contains chart name it will be used as a full name.
 */}}
-{{- define "kloudlite-operators.fullname" -}}
+{{- define "kloudlite-agent.fullname" -}}
 {{- if .Values.fullnameOverride }}
 {{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
 {{- else }}
@@ -26,16 +26,16 @@ If release name contains chart name it will be used as a full name.
 {{/*
 Create chart name and version as used by the chart label.
 */}}
-{{- define "kloudlite-operators.chart" -}}
+{{- define "kloudlite-agent.chart" -}}
 {{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
 {{- end }}
 
 {{/*
 Common labels
 */}}
-{{- define "kloudlite-operators.labels" -}}
-helm.sh/chart: {{ include "kloudlite-operators.chart" . }}
-{{ include "kloudlite-operators.selectorLabels" . }}
+{{- define "kloudlite-agent.labels" -}}
+helm.sh/chart: {{ include "kloudlite-agent.chart" . }}
+{{ include "kloudlite-agent.selectorLabels" . }}
 {{- if .Chart.AppVersion }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
@@ -45,17 +45,17 @@ app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{/*
 Selector labels
 */}}
-{{- define "kloudlite-operators.selectorLabels" -}}
-app.kubernetes.io/name: {{ include "kloudlite-operators.name" . }}
+{{- define "kloudlite-agent.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "kloudlite-agent.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
 
 {{/*
 Create the name of the service account to use
 */}}
-{{- define "kloudlite-operators.serviceAccountName" -}}
+{{- define "kloudlite-agent.serviceAccountName" -}}
 {{- if .Values.serviceAccount.create }}
-{{- default (include "kloudlite-operators.fullname" .) .Values.serviceAccount.name }}
+{{- default (include "kloudlite-agent.fullname" .) .Values.serviceAccount.name }}
 {{- else }}
 {{- default "default" .Values.serviceAccount.name }}
 {{- end }}

--- a/charts/kloudlite-agent/templates/_kl-helpers.tpl
+++ b/charts/kloudlite-agent/templates/_kl-helpers.tpl
@@ -1,0 +1,3 @@
+{{- define "serviceAccountName" -}}
+{{- printf "%s-%s" .Release.Name .Values.svcAccountName -}}
+{{- end}}

--- a/charts/kloudlite-agent/templates/rbac/service-account.yml.tpl
+++ b/charts/kloudlite-agent/templates/rbac/service-account.yml.tpl
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "serviceAccountName" . | quote }}
+  namespace: {{.Release.Namespace}}
+
+---
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{.Release.Namespace}}-{{- include "serviceAccountName" . }}-rb
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "serviceAccountName" . | quote }}
+    namespace: {{.Release.Namespace}}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: "ClusterRole"
+  name: cluster-admin
+
+---
+

--- a/charts/kloudlite-agent/values.yaml
+++ b/charts/kloudlite-agent/values.yaml
@@ -24,7 +24,7 @@ defaultImagePullSecretName: kl-image-pull-creds
 messageOfficeGRPCAddr: message-office-api.dev.kloudlite.io:443
 
 # -- k8s service account name, which all the pods installed by this chart uses
-svcAccountName: kloudlite-cluster-svc-account
+svcAccountName: cluster-svc-account
 
 agent:
   # -- enable/disable kloudlite agent

--- a/charts/kloudlite-platform/Chart.yaml
+++ b/charts/kloudlite-platform/Chart.yaml
@@ -22,3 +22,8 @@ dependencies:
     version: v1.11.0
     repository: https://charts.jetstack.io
     condition: cert-manager.install
+
+  # - name: vector
+  #   version: v0.22.1
+  #   repository: https://helm.vector.dev
+  #   condition: vector.install

--- a/charts/kloudlite-platform/values.yml.tpl
+++ b/charts/kloudlite-platform/values.yml.tpl
@@ -76,10 +76,10 @@ redpandaCluster:
 # -- configuration option for cert-manager (https://cert-manager.io/docs/installation/helm/)
 cert-manager:
   # -- whether to install cert-manager
-  install: false
+  install: true
 
   # -- cert-manager whether to install CRDs
-  installCRDs: true
+  installCRDs: false
 
   # -- cert-manager args, forcing recursive nameservers used to be google and cloudflare
   # @ignored
@@ -644,3 +644,5 @@ operators:
     # -- image (with tag) for byoc operator
     image: {{.ImageBYOCOperator}}
 
+{{/* vector: */}}
+{{/*   install: true */}}


### PR DESCRIPTION
## Description

This PR fixes some long time issue with our helm releaser github workflow
- now, it successfully checks whether github release exists or not
- if it does not exist, it creates it with auto generated release notes
- uploading and clobbering existing release assets was possible before, but 
  - `index.yaml` only listed artifacts of the current release, which meant all the previous release assets were not going to be listed through `helm repo search`
  - now, the current deployed `index.yaml` (if exists) is downloaded and parsed, and the new release assets are appended to the list of existing release assets, replacing only those entries which belong the current release tag

## Type of change
Please delete options that are not relevant.
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
