### PR TITLE
cookie domain now by default points to base domain

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -63,7 +63,8 @@ tasks:
         fi
         chmod +x {{.HELM_DOCS}}
 
-      # - docker run --rm --volume "$(pwd):/helm-docs" -u $(id -u) jnorwood/helm-docs:latest
+  generate-docs:
+    cmds:
       - |+
         {{.HELM_DOCS}}
 

--- a/charts/kloudlite-platform/Chart.yaml
+++ b/charts/kloudlite-platform/Chart.yaml
@@ -22,8 +22,3 @@ dependencies:
     version: v1.11.0
     repository: https://charts.jetstack.io
     condition: cert-manager.install
-
-  # - name: vector
-  #   version: v0.22.1
-  #   repository: https://helm.vector.dev
-  #   condition: vector.install

--- a/charts/kloudlite-platform/README.md
+++ b/charts/kloudlite-platform/README.md
@@ -83,16 +83,16 @@ helm show values kloudlite/kloudlite-platform
 | apps.authApi.configuration.oAuth2.enabled | bool | `false` | whether to enable oAuth2 |
 | apps.authApi.configuration.oAuth2.github.appId | string | `"<github-app-id>"` | github app Id |
 | apps.authApi.configuration.oAuth2.github.appPrivateKey | string | `"PGdpdGh1Yi1hcHAtcHJpdmF0ZS1rZXk+"` | github app private key (base64 encoded) |
-| apps.authApi.configuration.oAuth2.github.callbackUrl | string | `"https://auth.dev.kloudlite.io/oauth2/callback/github"` | github oAuth2 callback url |
+| apps.authApi.configuration.oAuth2.github.callbackUrl | string | `"https://auth.platform.kloudlite.io/oauth2/callback/github"` | github oAuth2 callback url |
 | apps.authApi.configuration.oAuth2.github.clientId | string | `"<github-client-id>"` | github oAuth2 Client ID |
 | apps.authApi.configuration.oAuth2.github.clientSecret | string | `"<github-client-secret>"` | github oAuth2 Client Secret |
 | apps.authApi.configuration.oAuth2.github.enabled | bool | `false` | whether to enable github oAuth2 |
 | apps.authApi.configuration.oAuth2.github.githubAppName | string | `"kloudlite-dev"` | github app name, that we want to install on user's github account |
-| apps.authApi.configuration.oAuth2.gitlab.callbackUrl | string | `"https://auth.dev.kloudlite.io/oauth2/callback/gitlab"` | gitlab oAuth2 callback url |
+| apps.authApi.configuration.oAuth2.gitlab.callbackUrl | string | `"https://auth.platform.kloudlite.io/oauth2/callback/gitlab"` | gitlab oAuth2 callback url |
 | apps.authApi.configuration.oAuth2.gitlab.clientId | string | `"<gitlab-client-id>"` | gitlab oAuth2 Client ID |
 | apps.authApi.configuration.oAuth2.gitlab.clientSecret | string | `"<gitlab-client-secret>"` | gitlab oAuth2 Client Secret |
 | apps.authApi.configuration.oAuth2.gitlab.enabled | bool | `false` | whether to enable gitlab oAuth2 |
-| apps.authApi.configuration.oAuth2.google.callbackUrl | string | `"https://auth.dev.kloudlite.io/oauth2/callback/google"` | google oAuth2 callback url |
+| apps.authApi.configuration.oAuth2.google.callbackUrl | string | `"https://auth.platform.kloudlite.io/oauth2/callback/google"` | google oAuth2 callback url |
 | apps.authApi.configuration.oAuth2.google.clientId | string | `"<google-client-id>"` | google oAuth2 Client ID |
 | apps.authApi.configuration.oAuth2.google.clientSecret | string | `"<google-client-secret>"` | google oAuth2 Client Secret |
 | apps.authApi.configuration.oAuth2.google.enabled | bool | `false` | whether to enable google oAuth2 |
@@ -111,13 +111,13 @@ helm show values kloudlite/kloudlite-platform
 | apps.containerRegistryApi.configuration.harbor.apiVersion | string | `"v2.0"` | harbor api version |
 | apps.containerRegistryApi.configuration.harbor.imageRegistryHost | string | `"<harbor-registry-host>"` | harbor image registry host |
 | apps.containerRegistryApi.configuration.harbor.webhookAuthz | string | `"<harbor-webhook-authz>"` | harbor webhook authz secret |
-| apps.containerRegistryApi.configuration.harbor.webhookEndpoint | string | `"https://webhooks.dev.kloudlite.io/harbor"` | harbor webhook endpoint, (for receiving webhooks for every images pushed) |
+| apps.containerRegistryApi.configuration.harbor.webhookEndpoint | string | `"https://webhooks.platform.kloudlite.io/harbor"` | harbor webhook endpoint, (for receiving webhooks for every images pushed) |
 | apps.containerRegistryApi.configuration.harbor.webhookName | string | `"kloudlite-dev-webhook"` | harbor webhook name |
 | apps.containerRegistryApi.enabled | bool | `false` |  |
 | apps.containerRegistryApi.image | string | `"ghcr.io/kloudlite/platform/apis/container-registry:v1.0.5-nightly"` | image (with tag) for container registry api |
-| apps.dnsApi.configuration | object | `{"dnsNames":["ns1.dev.kloudlite.io"],"edgeCNAME":"edge.dev.kloudlite.io"}` | configurations for dns api |
-| apps.dnsApi.configuration.dnsNames | list | `["ns1.dev.kloudlite.io"]` | list of all dnsNames for which, you want wildcard certificate to be issued for |
-| apps.dnsApi.configuration.edgeCNAME | string | `"edge.dev.kloudlite.io"` | base domain for CNAME for all the edges managed (or, to be managed) by this cluster |
+| apps.dnsApi.configuration | object | `{"dnsNames":["ns1.platform.kloudlite.io"],"edgeCNAME":"edge.platform.kloudlite.io"}` | configurations for dns api |
+| apps.dnsApi.configuration.dnsNames | list | `["ns1.platform.kloudlite.io"]` | list of all dnsNames for which, you want wildcard certificate to be issued for |
+| apps.dnsApi.configuration.edgeCNAME | string | `"edge.platform.kloudlite.io"` | base domain for CNAME for all the edges managed (or, to be managed) by this cluster |
 | apps.dnsApi.enabled | bool | `false` |  |
 | apps.dnsApi.image | string | `"ghcr.io/kloudlite/platform/apis/dns-api:v1.0.5-nightly"` | image (with tag) for dns api |
 | apps.financeApi.image | string | `"ghcr.io/kloudlite/platform/apis/finance:v1.0.5-nightly"` | image (with tag) for finance api |
@@ -133,16 +133,16 @@ helm show values kloudlite/kloudlite-platform
 | apps.webhooksApi.configuration.webhookAuthz.kloudliteSecret | string | `"<webhook-authz-kloudlite-secret>"` | webhook authz secret for kloudlite internal calls |
 | apps.webhooksApi.enabled | bool | `true` |  |
 | apps.webhooksApi.image | string | `"ghcr.io/kloudlite/platform/apis/webhooks:v1.0.5-nightly"` | image (with tag) for webhooks api |
-| baseDomain | string | `"dev.kloudlite.io"` | base domain for all routers exposed through this cluster |
-| cert-manager | object | `{"cainjector":{"podLabels":{},"resources":{"limits":{"cpu":"120m","memory":"200Mi"},"requests":{"cpu":"80m","memory":"200Mi"}}},"install":false,"installCRDs":true,"nodeSelector":{},"podLabels":{},"resources":{"limits":{"cpu":"80m","memory":"120Mi"},"requests":{"cpu":"40m","memory":"120Mi"}},"startupapicheck":{"enabled":false},"tolerations":[],"webhook":{"podLabels":{},"resources":{"limits":{"cpu":"60m","memory":"60Mi"},"requests":{"cpu":"30m","memory":"60Mi"}}}}` | configuration option for cert-manager (https://cert-manager.io/docs/installation/helm/) |
+| baseDomain | string | `"platform.kloudlite.io"` | base domain for all routers exposed through this cluster |
+| cert-manager | object | `{"cainjector":{"podLabels":{},"resources":{"limits":{"cpu":"120m","memory":"200Mi"},"requests":{"cpu":"80m","memory":"200Mi"}}},"install":true,"installCRDs":false,"nodeSelector":{},"podLabels":{},"resources":{"limits":{"cpu":"80m","memory":"120Mi"},"requests":{"cpu":"40m","memory":"120Mi"}},"startupapicheck":{"enabled":false},"tolerations":[],"webhook":{"podLabels":{},"resources":{"limits":{"cpu":"60m","memory":"60Mi"},"requests":{"cpu":"30m","memory":"60Mi"}}}}` | configuration option for cert-manager (https://cert-manager.io/docs/installation/helm/) |
 | cert-manager.cainjector.resources | object | `{"limits":{"cpu":"120m","memory":"200Mi"},"requests":{"cpu":"80m","memory":"200Mi"}}` | resource limits for cert-manager cainjector pods |
 | cert-manager.cainjector.resources.limits | object | `{"cpu":"120m","memory":"200Mi"}` | resource limits for cert-manager webhook pods |
 | cert-manager.cainjector.resources.limits.cpu | string | `"120m"` | cpu limit for cert-manager cainjector pods |
 | cert-manager.cainjector.resources.limits.memory | string | `"200Mi"` | memory limit for cert-manager cainjector pods |
 | cert-manager.cainjector.resources.requests.cpu | string | `"80m"` | cpu requests for cert-manager cainjector pods |
 | cert-manager.cainjector.resources.requests.memory | string | `"200Mi"` | memory requests for cert-manager cainjector pods |
-| cert-manager.install | bool | `false` | whether to install cert-manager |
-| cert-manager.installCRDs | bool | `true` | cert-manager whether to install CRDs |
+| cert-manager.install | bool | `true` | whether to install cert-manager |
+| cert-manager.installCRDs | bool | `false` | cert-manager whether to install CRDs |
 | cert-manager.resources.limits | object | `{"cpu":"80m","memory":"120Mi"}` | resource limits for cert-manager controller pods |
 | cert-manager.resources.limits.cpu | string | `"80m"` | cpu limit for cert-manager controller pods |
 | cert-manager.resources.limits.memory | string | `"120Mi"` | memory limit for cert-manager controller pods |
@@ -155,21 +155,22 @@ helm show values kloudlite/kloudlite-platform
 | cert-manager.webhook.resources.limits.memory | string | `"60Mi"` | memory limit for cert-manager webhook pods |
 | cert-manager.webhook.resources.requests.cpu | string | `"30m"` | cpu limit for cert-manager webhook pods |
 | cert-manager.webhook.resources.requests.memory | string | `"60Mi"` | memory limit for cert-manager webhook pods |
+| cloudflareWildCardCert.cloudflareCreds | object | `{"email":"<cloudflare-email>","secretToken":"<cloudflare-secret-token>"}` | cloudflare authz credentials |
+| cloudflareWildCardCert.cloudflareCreds.email | string | `"<cloudflare-email>"` | cloudflare authorized email |
+| cloudflareWildCardCert.cloudflareCreds.secretToken | string | `"<cloudflare-secret-token>"` | cloudflare authorized secret token |
+| cloudflareWildCardCert.create | bool | `true` |  |
+| cloudflareWildCardCert.domains | list | `["*.platform.kloudlite.io"]` | list of all SANs (Subject Alternative Names) for which wildcard certs should be created |
+| cloudflareWildCardCert.name | string | `"kl-cert-wildcard"` | name for wildcard cert |
+| cloudflareWildCardCert.secretName | string | `"kl-cert-wildcard-tls"` | k8s secret where wildcard cert should be stored |
 | clusterIssuer.acmeEmail | string | `"sample@example.com"` | email that should be used for communicating with letsencrypt services |
-| clusterIssuer.cloudflareWildCardCert.cloudflareCreds | object | `{"email":"<cloudflare-email>","secretToken":"<cloudflare-secret-token>"}` | cloudflare authz credentials |
-| clusterIssuer.cloudflareWildCardCert.cloudflareCreds.email | string | `"<cloudflare-email>"` | cloudflare authorized email |
-| clusterIssuer.cloudflareWildCardCert.cloudflareCreds.secretToken | string | `"<cloudflare-secret-token>"` | cloudflare authorized secret token |
-| clusterIssuer.cloudflareWildCardCert.create | bool | `false` |  |
-| clusterIssuer.cloudflareWildCardCert.domains | list | `["*.dev.kloudlite.io"]` | list of all SANs (Subject Alternative Names) for which wildcard certs should be created |
-| clusterIssuer.cloudflareWildCardCert.name | string | `"kl-cert-wildcard"` | name for wildcard cert |
-| clusterIssuer.cloudflareWildCardCert.secretName | string | `"kl-cert-wildcard-tls"` | k8s secret where wildcard cert should be stored |
-| clusterIssuer.install | bool | `true` | whether to install cluster issuer |
+| clusterIssuer.create | bool | `true` | whether to install cluster issuer |
 | clusterIssuer.name | string | `"cluster-issuer"` | name of cluster issuer, to be used for issuing wildcard cert |
 | clusterSvcAccount | string | `"kloudlite-cluster-svc-account"` | service account for privileged k8s operations, like creating namespaces, apps, routers etc. |
-| cookieDomain | string | `".kloudlite.io"` | cookie domain dictates at what domain, the cookies should be set for auth or other purposes |
+| cookieDomain | string | `".platform.kloudlite.io"` | cookie domain dictates at what domain, the cookies should be set for auth or other purposes |
 | defaultProjectWorkspaceName | string | `"default"` | default project workspace name, that should be auto created, whenever you create a project |
 | imagePullPolicy | string | `"Always"` | image pull policies for kloudlite pods, belonging to this chartvalues |
-| ingress-nginx | object | `{"controller":{"admissionWebhooks":{"enabled":false,"failurePolicy":"Ignore"},"electionID":"ingress-nginx","ingressClass":"ingress-nginx","ingressClassByName":true,"ingressClassResource":{"controllerValue":"k8s.io/ingress-nginx","enabled":true,"name":"ingress-nginx"},"kind":"Deployment","podLabels":{},"resources":{"requests":{"cpu":"100m","memory":"200Mi"}},"service":{"type":"LoadBalancer"},"watchIngressWithoutClass":false},"install":true,"nameOverride":"ingress-nginx","rbac":{"create":false},"serviceAccount":{"create":false,"name":"kloudlite-cluster-svc-account"}}` | ingress nginx configurations, read more at https://kubernetes.github.io/ingress-nginx/ |
+| ingress-nginx | object | `{"controller":{"admissionWebhooks":{"enabled":false,"failurePolicy":"Ignore"},"electionID":"ingress-nginx","extraArgs":{"default-ssl-certificate":"kl-cert-wildcard-tls"},"ingressClass":"ingress-nginx","ingressClassByName":true,"ingressClassResource":{"controllerValue":"k8s.io/ingress-nginx","enabled":true,"name":"ingress-nginx"},"kind":"Deployment","podLabels":{},"resources":{"requests":{"cpu":"100m","memory":"200Mi"}},"service":{"type":"LoadBalancer"},"watchIngressWithoutClass":false},"install":true,"nameOverride":"ingress-nginx","rbac":{"create":false},"serviceAccount":{"create":false,"name":"kloudlite-cluster-svc-account"}}` | ingress nginx configurations, read more at https://kubernetes.github.io/ingress-nginx/ |
+| ingress-nginx.controller.extraArgs | object | `{"default-ssl-certificate":"kl-cert-wildcard-tls"}` | ingress nginx controller extra args true |
 | ingress-nginx.controller.kind | string | `"Deployment"` | ingress nginx controller configuration |
 | ingress-nginx.install | bool | `true` | whether to install ingress-nginx |
 | ingressClassName | string | `"ingress-nginx"` | ingress class name that should be used for all the ingresses, created by this chart |
@@ -182,7 +183,7 @@ helm show values kloudlite/kloudlite-platform
 | kafka.topicHarborWebhooks | string | `"kl-harbor-webhooks"` | kafka topic for dispatching harbor webhook messages |
 | kafka.topicInfraStatusUpdates | string | `"kl-infra-updates"` | kafka topic for messages regarding infra resources on target clusters |
 | kafka.topicStatusUpdates | string | `"kl-status-updates"` | kafka topic for messages regarding kloudlite resources on target clusters |
-| nodeSelector | object | `{}` | node selectors to apply on all the pods belonging to this release |
+| nodeSelector | object | `{}` |  |
 | normalSvcAccount | string | `"kloudlite-svc-account"` | service account for non k8s operations, just for specifying image pull secrets |
 | operators.accountOperator | object | `{"enabled":true,"image":"ghcr.io/kloudlite/platform/operator/account:v1.0.5-nightly"}` | kloudlite account operator |
 | operators.accountOperator.enabled | bool | `true` | whether to enable account operator |
@@ -192,7 +193,7 @@ helm show values kloudlite/kloudlite-platform
 | operators.artifactsHarbor.configuration.harbor.apiVersion | string | `"v2.0"` | harbor api version |
 | operators.artifactsHarbor.configuration.harbor.imageRegistryHost | string | `"<harbor-registry-host>"` | harbor image registry host |
 | operators.artifactsHarbor.configuration.harbor.webhookAuthz | string | `"<harbor-webhook-authz>"` | harbor webhook authz secret |
-| operators.artifactsHarbor.configuration.harbor.webhookEndpoint | string | `"https://webhooks.dev.kloudlite.io/harbor"` | harbor webhook endpoint, (for receiving webhooks for every images pushed) |
+| operators.artifactsHarbor.configuration.harbor.webhookEndpoint | string | `"https://webhooks.platform.kloudlite.io/harbor"` | harbor webhook endpoint, (for receiving webhooks for every images pushed) |
 | operators.artifactsHarbor.configuration.harbor.webhookName | string | `"kloudlite-dev-webhook"` | harbor webhook name |
 | operators.artifactsHarbor.enabled | bool | `false` | whether to enable artifacts harbor operator |
 | operators.artifactsHarbor.image | string | `"ghcr.io/kloudlite/platform/operator/artifacts-harbor:v1.0.5-nightly"` | image (with tag) for artifacts harbor operator |

--- a/charts/kloudlite-platform/Taskfile.yml
+++ b/charts/kloudlite-platform/Taskfile.yml
@@ -19,7 +19,7 @@ tasks:
     vars:
       InstallationMode: dev
       BaseDomain: platform.kloudlite.io
-      CookieDomain: ."{{.BaseDomain}}"
+      CookieDomain: ".{{.BaseDomain}}"
 
       ImagePrefix: "ghcr.io/kloudlite"
       ImageVersionTag: "v1.0.5-nightly"
@@ -34,8 +34,10 @@ tasks:
 
       IngressClassName: ingress-nginx
 
-      WildcardCertEnabled: false
+      WildcardCertEnabled: true
       WildcardCertName: kl-cert-wildcard
+      WildcardCertNamespace: "{{.ReleaseNamespace}}"
+
       CloudflareEmail: '<cloudflare-email>'
       CloudflareSecretToken: '<cloudflare-secret-token>'
       AcmeEmail: 'sample@example.com'

--- a/charts/kloudlite-platform/Taskfile.yml
+++ b/charts/kloudlite-platform/Taskfile.yml
@@ -18,15 +18,12 @@ tasks:
   compile:
     vars:
       InstallationMode: dev
-      BaseDomain: dev.kloudlite.io
-      CookieDomain: .kloudlite.io
+      BaseDomain: platform.kloudlite.io
+      CookieDomain: ."{{.BaseDomain}}"
 
       ImagePrefix: "ghcr.io/kloudlite"
       ImageVersionTag: "v1.0.5-nightly"
     env:
-      EnvName: development
-      ImageTag: v1.0.5
-
       BaseDomain: "{{.BaseDomain}}"
       CookieDomain: "{{.CookieDomain}}"
 

--- a/charts/kloudlite-platform/templates/apis/infra-api.yml.tpl
+++ b/charts/kloudlite-platform/templates/apis/infra-api.yml.tpl
@@ -94,3 +94,6 @@ spec:
 
         - key: PROVIDER_SECRET_NAMESPACE
           value: {{.Release.Namespace}}
+
+        - key: IAM_GRPC_ADDR
+          value: {{.Values.apps.iamApi.name}}.{{.Release.Namespace}}.svc.cluster.local:{{.Values.apps.iamApi.configuration.grpcPort}}

--- a/charts/kloudlite-platform/templates/apis/message-office-api.yml.tpl
+++ b/charts/kloudlite-platform/templates/apis/message-office-api.yml.tpl
@@ -12,12 +12,12 @@ spec:
 
   services:
     - port: 80
-      targetPort: 3000
+      targetPort: {{.Values.apps.messageOfficeApi.configuration.httpPort}}
       name: http
       type: tcp
 
-    - port: 3001
-      targetPort: 3001
+    - port: {{.Values.apps.messageOfficeApi.configuration.grpcPort}}
+      targetPort: {{.Values.apps.messageOfficeApi.configuration.grpcPort}}
       name: grpc
       type: tcp
 
@@ -33,10 +33,10 @@ spec:
         max: "100Mi"
       env:
         - key: HTTP_PORT
-          value: "3000"
+          value: {{.Values.apps.messageOfficeApi.configuration.httpPort | squote}}
 
         - key: GRPC_PORT
-          value: '3001'
+          value: {{.Values.apps.messageOfficeApi.configuration.grpcPort | squote}}
       
         - key: DB_URI
           type: secret
@@ -78,6 +78,9 @@ spec:
         - key: KAFKA_TOPIC_BYOC_CLIENT_UPDATES
           value: {{.Values.kafka.topicBYOCClientUpdates}}
 
+        - key: KAFKA_CONSUMER_GROUP
+          value: {{.Values.kafka.consumerGroupId}}
+
         - key: KAFKA_BROKERS
           type: secret
           refName: "{{.Values.secretNames.redpandaAdminAuthSecret}}"
@@ -93,5 +96,5 @@ spec:
           refName: "{{.Values.secretNames.redpandaAdminAuthSecret}}"
           refKey: PASSWORD
 
-        - key: KAFKA_CONSUMER_GROUP
-          value: {{.Values.kafka.consumerGroupId}}
+        - key: KLOUDLITE_CONTAINER_REGISTRY_ENABLED
+          value: {{.Values.apps.containerRegistryApi.enabled | squote}}

--- a/charts/kloudlite-platform/templates/cert-manager/cf-wildcard-cert.yml.tpl
+++ b/charts/kloudlite-platform/templates/cert-manager/cf-wildcard-cert.yml.tpl
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{.Values.cloudflareWildCardCert.name}}-cf-api-token
-  namespace: {{.Values.cloudflareWildCardCert.namespace}}
+  namespace: {{.Release.Namespace}}
 stringData:
   api-token: {{.Values.cloudflareWildCardCert.cloudflareCreds.secretToken}}
 
@@ -13,7 +13,7 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: {{.Values.cloudflareWildCardCert.name}}
-  namespace: {{.Values.cloudflareWildCardCert.namespace}}
+  namespace: {{.Release.Namespace}}
 spec:
   dnsNames:
   {{range $v := .Values.cloudflareWildCardCert.domains}}

--- a/charts/kloudlite-platform/values.yaml
+++ b/charts/kloudlite-platform/values.yaml
@@ -1,7 +1,6 @@
 # -- image pull policies for kloudlite pods, belonging to this chartvalues
 imagePullPolicy: Always
 
-# -- node selectors to apply on all the pods belonging to this release
 nodeSelector: &nodeSelector {}
 
 # -- tolerations for pods belonging to this release
@@ -11,7 +10,10 @@ tolerations: &tolerations []
 podLabels: &podLabels {}
 
 # -- cookie domain dictates at what domain, the cookies should be set for auth or other purposes
-cookieDomain:  ".kloudlite.io"
+cookieDomain: '.platform.kloudlite.io'
+
+# -- base domain for all routers exposed through this cluster
+baseDomain: 'platform.kloudlite.io'
 
 # @ignored
 # -- account cookie name, that console-api should expect, while any client communicates through it's graphql interface
@@ -20,6 +22,12 @@ accountCookieName: "kloudlite-account"
 # -- cluster cookie name, that console-api should expect, while any client communicates through it's graphql interface
 # @ignored
 clusterCookieName: "kloudlite-cluster"
+
+# -- service account for privileged k8s operations, like creating namespaces, apps, routers etc.
+clusterSvcAccount: kloudlite-cluster-svc-account
+
+# -- service account for non k8s operations, just for specifying image pull secrets
+normalSvcAccount: kloudlite-svc-account
 
 # -- default project workspace name, that should be auto created, whenever you create a project
 defaultProjectWorkspaceName: "default"
@@ -76,10 +84,10 @@ redpandaCluster:
 # -- configuration option for cert-manager (https://cert-manager.io/docs/installation/helm/)
 cert-manager:
   # -- whether to install cert-manager
-  install: false
+  install: true
 
   # -- cert-manager whether to install CRDs
-  installCRDs: true
+  installCRDs: false
 
   # -- cert-manager args, forcing recursive nameservers used to be google and cloudflare
   # @ignored
@@ -189,6 +197,10 @@ ingress-nginx:
       enabled: true
       name: ingress-nginx
       controllerValue: "k8s.io/ingress-nginx"
+    # -- ingress nginx controller extra args true
+    extraArgs:
+      default-ssl-certificate: "kl-cert-wildcard-tls"
+    
 
     podLabels: *podLabels
 
@@ -206,40 +218,32 @@ operatorsNamespace: kl-init-operators
 
 clusterIssuer:
   # -- whether to install cluster issuer
-  install: true
+  create: true
 
   # -- name of cluster issuer, to be used for issuing wildcard cert
   name: "cluster-issuer"
   # -- email that should be used for communicating with letsencrypt services
   acmeEmail: sample@example.com
 
-  cloudflareWildCardCert:
-    create: false
+cloudflareWildCardCert:
+  create: true
 
-    # -- name for wildcard cert
-    name: kl-cert-wildcard
-    # -- k8s secret where wildcard cert should be stored
-    secretName: kl-cert-wildcard-tls
+  # -- name for wildcard cert
+  name: kl-cert-wildcard
 
-    # -- cloudflare authz credentials
-    cloudflareCreds:
-      # -- cloudflare authorized email
-      email: <cloudflare-email>
-      # -- cloudflare authorized secret token
-      secretToken: <cloudflare-secret-token>
+  # -- k8s secret where wildcard cert should be stored
+  secretName: kl-cert-wildcard-tls
 
-    # -- list of all SANs (Subject Alternative Names) for which wildcard certs should be created
-    domains: 
-      - "*.dev.kloudlite.io"
+  # -- cloudflare authz credentials
+  cloudflareCreds:
+    # -- cloudflare authorized email
+    email: <cloudflare-email>
+    # -- cloudflare authorized secret token
+    secretToken: <cloudflare-secret-token>
 
-# -- service account for privileged k8s operations, like creating namespaces, apps, routers etc.
-clusterSvcAccount: kloudlite-cluster-svc-account
-
-# -- service account for non k8s operations, just for specifying image pull secrets
-normalSvcAccount: kloudlite-svc-account
-
-# -- base domain for all routers exposed through this cluster
-baseDomain: dev.kloudlite.io
+  # -- list of all SANs (Subject Alternative Names) for which wildcard certs should be created
+  domains: 
+    - '*.platform.kloudlite.io'
 
 kafka:
   # -- consumer group ID for kafka consumers running with this helm chart
@@ -357,7 +361,7 @@ apps:
           # -- whether to enable github oAuth2
           enabled: false
           # -- github oAuth2 callback url
-          callbackUrl: https://auth.dev.kloudlite.io/oauth2/callback/github
+          callbackUrl: https://auth.platform.kloudlite.io/oauth2/callback/github
           # -- github oAuth2 Client ID
           clientId: <github-client-id>
           # -- github oAuth2 Client Secret
@@ -374,7 +378,7 @@ apps:
           # -- whether to enable gitlab oAuth2
           enabled: false
           # -- gitlab oAuth2 callback url
-          callbackUrl: https://auth.dev.kloudlite.io/oauth2/callback/gitlab
+          callbackUrl: https://auth.platform.kloudlite.io/oauth2/callback/gitlab
           # -- gitlab oAuth2 Client ID
           clientId: <gitlab-client-id>
           # -- gitlab oAuth2 Client Secret
@@ -386,7 +390,7 @@ apps:
           # -- whether to enable google oAuth2
           enabled: false
           # -- google oAuth2 callback url
-          callbackUrl: https://auth.dev.kloudlite.io/oauth2/callback/google
+          callbackUrl: https://auth.platform.kloudlite.io/oauth2/callback/google
           # -- google oAuth2 Client ID
           clientId: <google-client-id>
           # -- google oAuth2 Client Secret
@@ -404,9 +408,9 @@ apps:
     configuration:
       # -- list of all dnsNames for which, you want wildcard certificate to be issued for
       dnsNames: 
-        - "ns1.dev.kloudlite.io"
+        - "ns1.platform.kloudlite.io"
       # -- base domain for CNAME for all the edges managed (or, to be managed) by this cluster
-      edgeCNAME: "edge.dev.kloudlite.io"
+      edgeCNAME: "edge.platform.kloudlite.io"
 
   commsApi:
     # -- whether to enable communications api
@@ -507,7 +511,7 @@ apps:
         imageRegistryHost: <harbor-registry-host>
 
         # -- harbor webhook endpoint, (for receiving webhooks for every images pushed)
-        webhookEndpoint: https://webhooks.dev.kloudlite.io/harbor 
+        webhookEndpoint: https://webhooks.platform.kloudlite.io/harbor 
         # -- harbor webhook name
         webhookName: kloudlite-dev-webhook
         # -- harbor webhook authz secret
@@ -609,4 +613,6 @@ operators:
 
     # -- image (with tag) for byoc operator
     image: ghcr.io/kloudlite/platform/operator/byoc:v1.0.5-nightly
+
+
 

--- a/charts/kloudlite-platform/values.yml.tpl
+++ b/charts/kloudlite-platform/values.yml.tpl
@@ -1,7 +1,6 @@
 # -- image pull policies for kloudlite pods, belonging to this chartvalues
 imagePullPolicy: Always
 
-# -- node selectors to apply on all the pods belonging to this release
 nodeSelector: &nodeSelector {}
 
 # -- tolerations for pods belonging to this release
@@ -13,6 +12,9 @@ podLabels: &podLabels {}
 # -- cookie domain dictates at what domain, the cookies should be set for auth or other purposes
 cookieDomain:  "{{.CookieDomain}}"
 
+# -- base domain for all routers exposed through this cluster
+baseDomain: {{.BaseDomain}}
+
 # @ignored
 # -- account cookie name, that console-api should expect, while any client communicates through it's graphql interface
 accountCookieName: "kloudlite-account"
@@ -20,6 +22,12 @@ accountCookieName: "kloudlite-account"
 # -- cluster cookie name, that console-api should expect, while any client communicates through it's graphql interface
 # @ignored
 clusterCookieName: "kloudlite-cluster"
+
+# -- service account for privileged k8s operations, like creating namespaces, apps, routers etc.
+clusterSvcAccount: {{.ClusterSvcAccount}}
+
+# -- service account for non k8s operations, just for specifying image pull secrets
+normalSvcAccount: {{.NormalSvcAccount}}
 
 # -- default project workspace name, that should be auto created, whenever you create a project
 defaultProjectWorkspaceName: "{{.DefaultProjectWorkspaceName}}"
@@ -266,16 +274,7 @@ cloudflareWildCardCert:
 
   # -- list of all SANs (Subject Alternative Names) for which wildcard certs should be created
   domains: 
-    - "*.{{.BaseDomain}}"
-
-# -- service account for privileged k8s operations, like creating namespaces, apps, routers etc.
-clusterSvcAccount: {{.ClusterSvcAccount}}
-
-# -- service account for non k8s operations, just for specifying image pull secrets
-normalSvcAccount: {{.NormalSvcAccount}}
-
-# -- base domain for all routers exposed through this cluster
-baseDomain: {{.BaseDomain}}
+    - '*.{{.BaseDomain}}'
 
 kafka:
   # -- consumer group ID for kafka consumers running with this helm chart

--- a/charts/kloudlite-platform/values.yml.tpl
+++ b/charts/kloudlite-platform/values.yml.tpl
@@ -10,10 +10,10 @@ tolerations: &tolerations []
 podLabels: &podLabels {}
 
 # -- cookie domain dictates at what domain, the cookies should be set for auth or other purposes
-cookieDomain:  "{{.CookieDomain}}"
+cookieDomain: {{.CookieDomain | squote}}
 
 # -- base domain for all routers exposed through this cluster
-baseDomain: {{.BaseDomain}}
+baseDomain: {{.BaseDomain | squote }}
 
 # @ignored
 # -- account cookie name, that console-api should expect, while any client communicates through it's graphql interface
@@ -243,9 +243,6 @@ ingress-nginx:
       enabled: false
       failurePolicy: Ignore
 
-# -- namespace where chart kloudlite-operators have been installed
-operatorsNamespace: {{.OperatorsNamespace}}
-
 clusterIssuer:
   # -- whether to install cluster issuer
   create: true
@@ -260,8 +257,7 @@ cloudflareWildCardCert:
 
   # -- name for wildcard cert
   name: {{.WildcardCertName}}
-  # -- namespace for wildcard cert, (only if clusterIssuer.install == false)
-  namepace: {{.WildcardCertNamespace}}
+
   # -- k8s secret where wildcard cert should be stored
   secretName: {{.WildcardCertName}}-tls
 
@@ -531,6 +527,7 @@ apps:
       # @ignored
       grpcPort: 3001
 
+      # -- harbor configuration, required only if .apps.containerRegistryApi.enabled 
       harbor: &harborConfiguration
         # -- harbor api version
         apiVersion: v2.0
@@ -610,6 +607,13 @@ apps:
 
     # -- image (with tag) for message office api
     image: {{.ImageMessageOfficeApi}}
+
+    configuration:
+      # @ignored
+      grpcPort: 3001
+
+      # @ignored
+      httpPort: 3000
 
 operators:
   # -- kloudlite account operator


### PR DESCRIPTION
## Description

### charts/kloudlite-platform
- cookie domain by default, is `.{{baseDomain}}`
- cert-manager CRDs installation (won't be supported by helm chart), and ideal way is to install it from outside only
- redpanda CRDs installation (won't be supported by helm chart), and ideal way is to install it from outside only
- deployment configuration updates for infra api, and message-office-api
- certmanager installation and wildcard configuration updates and refactoring
