### PR TITLE
Ci/migrating workflow to use pip

### DIFF
--- a/.github/workflows/helm-release.yml
+++ b/.github/workflows/helm-release.yml
@@ -53,12 +53,17 @@ jobs:
         with:
           python-version: 3.9
 
-      - name: Setup pipx
-        uses: CfirTsabari/actions-pipx@v1
+      # - name: Setup pipx
+      #   uses: CfirTsabari/actions-pipx@v1
 
-      - name: Installing yq (with pipx)
+      # - name: Installing yq (with pipx)
+      #   run: |+
+      #     pipx install yq
+
+      - name: Installing yq (with pip)
         run: |+
-          pipx install yq
+          pip install yq
+
 
       - name: Add repositories
         run: |
@@ -72,10 +77,6 @@ jobs:
       - name: Setting up Chart Releaser
         run: |+
           curl -L0 https://github.com/helm/chart-releaser/releases/download/v1.5.0/chart-releaser_1.5.0_linux_amd64.tar.gz > /tmp/chart-releaser.tar.gz && tar xf /tmp/chart-releaser.tar.gz -C /tmp && mv /tmp/cr /usr/local/bin/cr
-
-      - name: Installing Github Cli
-        run: |+
-          curl -L0 https://github.com/cli/cli/releases/download/v2.29.0/gh_2.29.0_linux_amd64.tar.gz > /tmp/gh_2.29.0_linux_amd64.tar.gz && tar xf /tmp/gh_2.29.0_linux_amd64.tar.gz -C /tmp && mv /tmp/gh_2.29.0_linux_amd64/bin/gh /usr/local/bin/gh
 
       - name: Installing Github Cli
         run: |+

--- a/.github/workflows/helm-release.yml
+++ b/.github/workflows/helm-release.yml
@@ -53,13 +53,6 @@ jobs:
         with:
           python-version: 3.9
 
-      # - name: Setup pipx
-      #   uses: CfirTsabari/actions-pipx@v1
-
-      # - name: Installing yq (with pipx)
-      #   run: |+
-      #     pipx install yq
-
       - name: Installing yq (with pip)
         run: |+
           pip install yq
@@ -149,7 +142,7 @@ jobs:
           for dir in $(ls -d charts/*); do
             export CHART_NAME=$(basename $dir)
             
-            cat $tar_dir/index.yaml | yq '. | .entries[env.CHART_NAME] = (.entries[env.CHART_NAME] | map_values(select( (. != null) and (.appVersion != env.RELEASE_TAG) )))' -y | tee /tmp/index2.yaml
+            cat $tar_dir/index.yaml | yq '. | .entries[env.CHART_NAME] = (.entries[env.CHART_NAME] | map_values(select( (. != null) and (.appVersion != env.RELEASE_TAG) )))' -y > /tmp/index2.yaml
 
             mv /tmp/index2.yaml $tar_dir/index.yaml
           done
@@ -157,6 +150,7 @@ jobs:
           helm repo index $tar_dir --url https://github.com/$GITHUB_REPOSITORY/releases/download/$RELEASE_TAG --merge $tar_dir/index.yaml
           mkdir -p .static-pages
           cp $tar_dir/index.yaml .static-pages/index.yaml
+          gh release upload $RELEASE_TAG ${uploadOpts[@]} .static-pages/index.yaml
 
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v1

--- a/.github/workflows/helm-release.yml
+++ b/.github/workflows/helm-release.yml
@@ -142,12 +142,14 @@ jobs:
 
           # remove entries related to the current release_tag, for all the charts
           curl -f -L0 https://${{github.repository_owner}}.github.io/${{github.event.repository.name}}/index.yaml > $tar_dir/index.yaml
+          echo "++++++++++++++++++++ Current index.yaml ++++++++++++++++++++"
           cat $tar_dir/index.yaml
+          echo "++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++"
 
           for dir in $(ls -d charts/*); do
             export CHART_NAME=$(basename $dir)
             
-            cat $tar_dir/index.yaml | yq '. | .entries[env.CHART_NAME] = (.entries[env.CHART_NAME] | map_values(select(.appVersion != env.RELEASE_TAG)))' -y | tee /tmp/index2.yaml
+            cat $tar_dir/index.yaml | yq '. | .entries[env.CHART_NAME] = (.entries[env.CHART_NAME] | map_values(select( (. != null) and (.appVersion != env.RELEASE_TAG) )))' -y | tee /tmp/index2.yaml
 
             mv /tmp/index2.yaml $tar_dir/index.yaml
           done
@@ -155,7 +157,6 @@ jobs:
           helm repo index $tar_dir --url https://github.com/$GITHUB_REPOSITORY/releases/download/$RELEASE_TAG --merge $tar_dir/index.yaml
           mkdir -p .static-pages
           cp $tar_dir/index.yaml .static-pages/index.yaml
-
 
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v1


### PR DESCRIPTION
## Description
 
CI Updates:
  -  removes pipx setup from CI, and using plain pip to install yq
  - updates to yq filters, as previous filters resulted in `null` entries, which lead to `helm repo index` crashing, now we ensure we skip null values