### PR TITLE
feat(kloudlite-agent): kubelet-metrics-reexporter updates

### DIFF
--- a/charts/kloudlite-agent/values.yml.tpl
+++ b/charts/kloudlite-agent/values.yml.tpl
@@ -91,6 +91,8 @@ vector:
         - "kl_account_name={{.AccountName}}"
         - --enrich-tag
         - "kl_cluster_name={{.ClusterName}}"
+        - --enrich-tag
+        - "kl_resource_namespace={{ "{{" }}.Namespace{{ "}}" }}"
         - --filter-prefix
         - "kloudlite.io/"
         - --replace-prefix


### PR DESCRIPTION
for metrics, tag `kl_resource_namespace` will now be enriched by [kubelet-metrics-reexporter](https://github.com/nxtcoder17/kubelet-metrics-reexporter). 
It makes use of recently introduced template values in enrich-tags.
