### PR TITLE
feat(charts/kloudlite-platform): redpanda bumped to v23.2.9

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -77,7 +77,7 @@ tasks:
 
   crds:
     vars:
-      OutputDir: "/tmp/crds"
+      OutputDir: "./crds"
       OperatorDir: "../operator"
       HelmOperatorDir: "../helm-operator"
       RedpandaVersion: v22.1.6
@@ -98,7 +98,10 @@ tasks:
         curl -L0 https://github.com/cert-manager/cert-manager/releases/download/v1.12.0/cert-manager.crds.yaml > {{.OutputDir}}/crds-cert-manager.yml
 
         # redpanda CRDs
-        curl -L0 https://raw.githubusercontent.com/redpanda-data/redpanda/{{.RedpandaVersion}}/src/go/k8s/config/crd/bases/redpanda.vectorized.io_clusters.yaml > {{.OutputDir}}/crds-redpanda.yml
+        # curl -L0 https://raw.githubusercontent.com/redpanda-data/redpanda/{{.RedpandaVersion}}/src/go/k8s/config/crd/bases/redpanda.vectorized.io_clusters.yaml > {{.OutputDir}}/crds-redpanda.yml
+
+        # redpanda CRDs
+        kubectl kustomize https://github.com/redpanda-data/redpanda//src/go/k8s/config/crd > {{.OutputDir}}/crds-redpanda.yml
 
 
   test-release-script:

--- a/charts/kloudlite-operators/values.yml.tpl
+++ b/charts/kloudlite-operators/values.yml.tpl
@@ -104,16 +104,3 @@ operators:
     name: kl-helm-charts-operator
     # -- helm-charts operator image and tag
     image: {{.ImageHelmChartsOperator}}
-
-    configuration:
-      # -- affinity configuration for pod template, for pod affinity to node
-      affinity:
-        nodeAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-            nodeSelectorTerms:
-              - matchExpressions:
-                  - key: node-role.kubernetes.io/master
-                    operator: In
-                    values:
-                      - "true"
-

--- a/charts/kloudlite-platform/templates/apis/accounts-api.yml.tpl
+++ b/charts/kloudlite-platform/templates/apis/accounts-api.yml.tpl
@@ -4,7 +4,7 @@ metadata:
   name: {{.Values.apps.accountsApi.name}}
   namespace: {{.Release.Namespace}}
 spec:
-  region: {{.Values.region | default ""}}
+  {{- /* region: {{.Values.region | default ""}} */}}
   serviceAccount: {{ .Values.clusterSvcAccount }}
 
   {{ include "node-selector-and-tolerations" . | nindent 2 }}
@@ -67,17 +67,17 @@ spec:
           value: "{{.Values.cookieDomain}}"
 
         - key: IAM_GRPC_ADDR
-          value: "{{.Values.apps.iamApi.name}}.{{.Release.Namespace}}.svc.cluster.local:{{.Values.apps.iamApi.configuration.grpcPort}}"
+          value: "{{.Values.apps.iamApi.name}}.{{.Release.Namespace}}.{{.Values.clusterInternalDNS}}:{{.Values.apps.iamApi.configuration.grpcPort}}"
 
         - key: COMMS_GRPC_ADDR
-          value: "{{.Values.apps.commsApi.name}}.{{.Release.Namespace}}.svc.cluster.local:{{.Values.apps.commsApi.configuration.grpcPort}}"
+          value: "{{.Values.apps.commsApi.name}}.{{.Release.Namespace}}.{{.Values.clusterInternalDNS}}:{{.Values.apps.commsApi.configuration.grpcPort}}"
 
         - key: CONTAINER_REGISTRY_GRPC_ADDR
-          value: "{{.Values.apps.containerRegistryApi.name}}.{{.Release.Namespace}}.svc.cluster.local:{{.Values.apps.containerRegistryApi.configuration.grpcPort}}"
+          value: "{{.Values.apps.containerRegistryApi.name}}.{{.Release.Namespace}}.{{.Values.clusterInternalDNS}}:{{.Values.apps.containerRegistryApi.configuration.grpcPort}}"
 
         - key: CONSOLE_GRPC_ADDR
-          value: "{{.Values.apps.consoleApi.name}}.{{.Release.Namespace}}.svc.cluster.local:{{.Values.apps.consoleApi.configuration.grpcPort}}"
+          value: "{{.Values.apps.consoleApi.name}}.{{.Release.Namespace}}.{{.Values.clusterInternalDNS}}:{{.Values.apps.consoleApi.configuration.grpcPort}}"
 
         - key: AUTH_GRPC_ADDR
-          value: "{{.Values.apps.authApi.name}}.{{.Release.Namespace}}.svc.cluster.local:{{.Values.apps.authApi.configuration.grpcPort}}"
+          value: "{{.Values.apps.authApi.name}}.{{.Release.Namespace}}.{{.Values.clusterInternalDNS}}:{{.Values.apps.authApi.configuration.grpcPort}}"
 

--- a/charts/kloudlite-platform/templates/apis/console-api.yml.tpl
+++ b/charts/kloudlite-platform/templates/apis/console-api.yml.tpl
@@ -100,7 +100,7 @@ spec:
           value: {{.Values.kafka.consumerGroupId}}
 
         - key: IAM_GRPC_ADDR
-          value: {{.Values.apps.iamApi.name}}.{{.Release.Namespace}}.svc.cluster.local:{{.Values.apps.iamApi.configuration.grpcPort}}
+          value: {{.Values.apps.iamApi.name}}.{{.Release.Namespace}}.{{.Values.clusterInternalDNS}}:{{.Values.apps.iamApi.configuration.grpcPort}}
 
         - key: DEFAULT_PROJECT_WORKSPACE_NAME
           value: {{.Values.defaultProjectWorkspaceName}}
@@ -109,11 +109,10 @@ spec:
           value: /console.d/templates/managed-svc-templates.yml
 
         - key: LOKI_SERVER_HTTP_ADDR
-          value: http://{{include "loki.name" . }}.{{.Release.Namespace}}.svc.cluster.local:3100
+          value: http://{{ (index .Values.helmCharts "loki-stack").name }}.{{.Release.Namespace}}.{{.Values.clusterInternalDNS}}:3100
 
         - key: PROM_HTTP_ADDR
-          {{- /* value: http://{{include "kube-prometheus.name" . }}.{{.Release.Namespace}}.svc.cluster.local:9090 */}}
-          value: http://kloudlite-platform-kube-pr-prometheus.{{.Release.Namespace}}.svc.cluster.local:9090
+          value: http://{{ (index .Values.helmCharts "kube-prometheus").name }}-prometheus.{{.Release.Namespace}}.{{.Values.clusterInternalDNS}}:9090
 
       volumes:
         - mountPath: /console.d/templates

--- a/charts/kloudlite-platform/templates/helm-charts/helm-redpanda-operator.yml.tpl
+++ b/charts/kloudlite-platform/templates/helm-charts/helm-redpanda-operator.yml.tpl
@@ -9,18 +9,30 @@ metadata:
 spec:
   chartRepo:
     name: redpanda
-    url: https://charts.vectorized.io
+    url: https://charts.redpanda.com
 
-  chartName: redpanda/redpanda-operator
-  chartVersion: 22.1.6
+  chartName: redpanda/operator
+  {{- /* chartVersion: 5.5.1 */}}
+  chartVersion: 0.3.21
 
-  valuesYaml: |
+  valuesYaml: |+
     nameOverride: {{$chartOpts.name}}
     fullnameOverride: {{$chartOpts.name}}
 
-    resources: {{$chartOpts.configuration.resources}}
+    image:
+      repository: docker.redpanda.com/redpandadata/redpanda-operator
+      tag: v23.2.9
 
-    webhook:
-      enabled: false
+  {{- /* chartName: redpanda/redpanda-operator */}}
+  {{- /* chartVersion: 22.1.6 */}}
+  {{- /**/}}
+  {{- /* valuesYaml: | */}}
+  {{- /*   nameOverride: {{$chartOpts.name}} */}}
+  {{- /*   fullnameOverride: {{$chartOpts.name}} */}}
+  {{- /**/}}
+  {{- /*   resources: {{$chartOpts.configuration.resources}} */}}
+  {{- /**/}}
+  {{- /*   webhook: */}}
+  {{- /*     enabled: false */}}
 
 {{- end }}

--- a/charts/kloudlite-platform/templates/redpanda/_one-node-cluster.yml.tpl
+++ b/charts/kloudlite-platform/templates/redpanda/_one-node-cluster.yml.tpl
@@ -9,7 +9,7 @@ spec:
   image: "vectorized/redpanda"
   version: {{.Values.redpandaCluster.version}}
   replicas: {{.Values.redpandaCluster.replicas}}
-  resources: {{.Values.redpandaCluster.resources | toPrettyJson }}
+  resources: {{.Values.redpandaCluster.resources | toYaml | nindent 4 }}
 
   {{/* enableSasl: true */}}
   {{/* superusers: */}}

--- a/charts/kloudlite-platform/templates/redpanda/_sample-topic.yml.tpl
+++ b/charts/kloudlite-platform/templates/redpanda/_sample-topic.yml.tpl
@@ -1,0 +1,10 @@
+apiVersion: cluster.redpanda.com/v1alpha1
+kind: Topic
+metadata:
+  name: sample-topic
+  namespace: kl-core
+spec:
+  partitions: 3
+  kafkaApiSpec:
+    brokers:
+      - redpanda-0.redpanda.kl-core.svc.cluster.local:9092

--- a/charts/kloudlite-platform/templates/redpanda/admin/redpanda-admin.yml.tpl
+++ b/charts/kloudlite-platform/templates/redpanda/admin/redpanda-admin.yml.tpl
@@ -5,4 +5,9 @@ metadata:
   namespace: {{.Release.Namespace}}
 spec:
   adminEndpoint: {{.Values.redpandaCluster.name}}.{{.Release.Namespace}}.svc.cluster.local:9644
-  kafkaBrokers: {{.Values.redpandaCluster.name}}.{{.Release.Namespace}}.svc.cluster.local:9092
+  {{- $kafkaBrokers := list }} 
+  {{- range $i, $e := until (int .Values.redpandaCluster.replicas) }}
+  {{- $kafkaBrokers = append $kafkaBrokers (printf "%s-%d.%s.%s.%s:9092" $.Values.redpandaCluster.name $i $.Values.redpandaCluster.name $.Release.Namespace $.Values.clusterInternalDNS) }}
+  {{- end }}
+  {{- /* kafkaBrokers: {{.Values.redpandaCluster.name}}-0.{{.Values.redpandaCluster.name}}.{{.Release.Namespace}}.svc.cluster.local:9092 */}}
+  kafkaBrokers: {{ join "," $kafkaBrokers }}

--- a/charts/kloudlite-platform/templates/redpanda/redpanda-cluster.yml.tpl
+++ b/charts/kloudlite-platform/templates/redpanda/redpanda-cluster.yml.tpl
@@ -1,0 +1,39 @@
+{{- if .Values.redpandaCluster.create }}
+apiVersion: cluster.redpanda.com/v1alpha1
+kind: Redpanda
+metadata:
+  name: redpanda
+spec:
+  chartRef: {}
+  clusterSpec:
+    auth:
+      sasl:
+        enabled: false
+        users: []
+
+    tls:
+      enabled: false
+    external:
+      enabled: false
+
+    listeners:
+      kafka:
+        port: 9092
+
+    statefulset:
+      replicas: 1
+      additionalRedpandaCmdFlags:
+        - --mode
+        - dev-container
+      initContainers:
+        setDataDirOwnership:
+          enabled: true
+
+    resources:
+      cpu:
+        cores: 1
+      memory:
+        container:
+          min: 1Gi
+          max: 1Gi
+{{- end }}

--- a/charts/kloudlite-platform/values.yaml
+++ b/charts/kloudlite-platform/values.yaml
@@ -15,6 +15,9 @@ cookieDomain: '.platform.kloudlite.io'
 # -- base domain for all routers exposed through this cluster
 baseDomain: 'platform.kloudlite.io'
 
+# -- cluster internal DNS name
+clusterInternalDNS: "svc.cluster.local"
+
 # @ignored
 # -- account cookie name, that console-api should expect, while any client communicates through it's graphql interface
 accountCookieName: "kloudlite-account"
@@ -33,6 +36,10 @@ normalSvcAccount: kloudlite-svc-account
 defaultProjectWorkspaceName: "default"
 
 helmCharts:
+  cert-manager:
+    enabled: true
+    name: cert-manager
+
   ingress-nginx:
     enabled: true
     name: ingress-nginx
@@ -41,6 +48,7 @@ helmCharts:
       # -- can be DaemonSet or Deployment
       controllerKind: "Deployment"
       ingressClassName: "ingress-nginx"
+
 
   loki-stack:
     enabled: true

--- a/charts/kloudlite-platform/values.yml.tpl
+++ b/charts/kloudlite-platform/values.yml.tpl
@@ -15,6 +15,9 @@ cookieDomain: {{.CookieDomain | squote}}
 # -- base domain for all routers exposed through this cluster
 baseDomain: {{.BaseDomain | squote }}
 
+# -- cluster internal DNS name
+clusterInternalDNS: "svc.cluster.local"
+
 # @ignored
 # -- account cookie name, that console-api should expect, while any client communicates through it's graphql interface
 accountCookieName: "kloudlite-account"
@@ -33,6 +36,10 @@ normalSvcAccount: {{.NormalSvcAccount}}
 defaultProjectWorkspaceName: "{{.DefaultProjectWorkspaceName}}"
 
 helmCharts:
+  cert-manager:
+    enabled: true
+    name: cert-manager
+
   ingress-nginx:
     enabled: true
     name: ingress-nginx
@@ -41,6 +48,7 @@ helmCharts:
       # -- can be DaemonSet or Deployment
       controllerKind: "{{.IngressControllerKind}}"
       ingressClassName: "{{.IngressClassName}}"
+
 
   loki-stack:
     enabled: true

--- a/crds/crds-redpanda.yml
+++ b/crds/crds-redpanda.yml
@@ -1,4 +1,517 @@
-
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.8.0
+  creationTimestamp: null
+  name: buckets.source.toolkit.fluxcd.io
+spec:
+  group: source.toolkit.fluxcd.io
+  names:
+    kind: Bucket
+    listKind: BucketList
+    plural: buckets
+    singular: bucket
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .spec.endpoint
+      name: Endpoint
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Ready")].message
+      name: Status
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: Bucket is the Schema for the buckets API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: BucketSpec defines the desired state of an S3 compatible
+              bucket
+            properties:
+              accessFrom:
+                description: AccessFrom defines an Access Control List for allowing
+                  cross-namespace references to this object.
+                properties:
+                  namespaceSelectors:
+                    description: NamespaceSelectors is the list of namespace selectors
+                      to which this ACL applies. Items in this list are evaluated
+                      using a logical OR operation.
+                    items:
+                      description: NamespaceSelector selects the namespaces to which
+                        this ACL applies. An empty map of MatchLabels matches all
+                        namespaces in a cluster.
+                      properties:
+                        matchLabels:
+                          additionalProperties:
+                            type: string
+                          description: MatchLabels is a map of {key,value} pairs.
+                            A single {key,value} in the matchLabels map is equivalent
+                            to an element of matchExpressions, whose key field is
+                            "key", the operator is "In", and the values array contains
+                            only "value". The requirements are ANDed.
+                          type: object
+                      type: object
+                    type: array
+                required:
+                - namespaceSelectors
+                type: object
+              bucketName:
+                description: The bucket name.
+                type: string
+              endpoint:
+                description: The bucket endpoint address.
+                type: string
+              ignore:
+                description: Ignore overrides the set of excluded patterns in the
+                  .sourceignore format (which is the same as .gitignore). If not provided,
+                  a default will be used, consult the documentation for your version
+                  to find out what those are.
+                type: string
+              insecure:
+                description: Insecure allows connecting to a non-TLS S3 HTTP endpoint.
+                type: boolean
+              interval:
+                description: The interval at which to check for bucket updates.
+                type: string
+              provider:
+                default: generic
+                description: The S3 compatible storage provider name, default ('generic').
+                enum:
+                - generic
+                - aws
+                - gcp
+                type: string
+              region:
+                description: The bucket region.
+                type: string
+              secretRef:
+                description: The name of the secret containing authentication credentials
+                  for the Bucket.
+                properties:
+                  name:
+                    description: Name of the referent.
+                    type: string
+                required:
+                - name
+                type: object
+              suspend:
+                description: This flag tells the controller to suspend the reconciliation
+                  of this source.
+                type: boolean
+              timeout:
+                default: 60s
+                description: The timeout for download operations, defaults to 60s.
+                type: string
+            required:
+            - bucketName
+            - endpoint
+            - interval
+            type: object
+          status:
+            default:
+              observedGeneration: -1
+            description: BucketStatus defines the observed state of a bucket
+            properties:
+              artifact:
+                description: Artifact represents the output of the last successful
+                  Bucket sync.
+                properties:
+                  checksum:
+                    description: Checksum is the SHA256 checksum of the artifact.
+                    type: string
+                  lastUpdateTime:
+                    description: LastUpdateTime is the timestamp corresponding to
+                      the last update of this artifact.
+                    format: date-time
+                    type: string
+                  path:
+                    description: Path is the relative file path of this artifact.
+                    type: string
+                  revision:
+                    description: Revision is a human readable identifier traceable
+                      in the origin source system. It can be a Git commit SHA, Git
+                      tag, a Helm index timestamp, a Helm chart version, etc.
+                    type: string
+                  url:
+                    description: URL is the HTTP address of this artifact.
+                    type: string
+                required:
+                - path
+                - url
+                type: object
+              conditions:
+                description: Conditions holds the conditions for the Bucket.
+                items:
+                  description: "Condition contains details for one aspect of the current
+                    state of this API Resource. --- This struct is intended for direct
+                    use as an array at the field path .status.conditions.  For example,
+                    \n type FooStatus struct{ // Represents the observations of a
+                    foo's current state. // Known .status.conditions.type are: \"Available\",
+                    \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge
+                    // +listType=map // +listMapKey=type Conditions []metav1.Condition
+                    `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\"
+                    protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields }"
+                  properties:
+                    lastTransitionTime:
+                      description: lastTransitionTime is the last time the condition
+                        transitioned from one status to another. This should be when
+                        the underlying condition changed.  If that is not known, then
+                        using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: message is a human readable message indicating
+                        details about the transition. This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: observedGeneration represents the .metadata.generation
+                        that the condition was set based upon. For instance, if .metadata.generation
+                        is currently 12, but the .status.conditions[x].observedGeneration
+                        is 9, the condition is out of date with respect to the current
+                        state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: reason contains a programmatic identifier indicating
+                        the reason for the condition's last transition. Producers
+                        of specific condition types may define expected values and
+                        meanings for this field, and whether the values are considered
+                        a guaranteed API. The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        --- Many .condition.type values are consistent across resources
+                        like Available, but because arbitrary conditions can be useful
+                        (see .node.status.conditions), the ability to deconflict is
+                        important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              lastHandledReconcileAt:
+                description: LastHandledReconcileAt holds the value of the most recent
+                  reconcile request value, so a change of the annotation value can
+                  be detected.
+                type: string
+              observedGeneration:
+                description: ObservedGeneration is the last observed generation.
+                format: int64
+                type: integer
+              url:
+                description: URL is the download link for the artifact output of the
+                  last Bucket sync.
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
+  - additionalPrinterColumns:
+    - jsonPath: .spec.endpoint
+      name: Endpoint
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Ready")].message
+      name: Status
+      type: string
+    name: v1beta2
+    schema:
+      openAPIV3Schema:
+        description: Bucket is the Schema for the buckets API.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: BucketSpec specifies the required configuration to produce
+              an Artifact for an object storage bucket.
+            properties:
+              accessFrom:
+                description: 'AccessFrom specifies an Access Control List for allowing
+                  cross-namespace references to this object. NOTE: Not implemented,
+                  provisional as of https://github.com/fluxcd/flux2/pull/2092'
+                properties:
+                  namespaceSelectors:
+                    description: NamespaceSelectors is the list of namespace selectors
+                      to which this ACL applies. Items in this list are evaluated
+                      using a logical OR operation.
+                    items:
+                      description: NamespaceSelector selects the namespaces to which
+                        this ACL applies. An empty map of MatchLabels matches all
+                        namespaces in a cluster.
+                      properties:
+                        matchLabels:
+                          additionalProperties:
+                            type: string
+                          description: MatchLabels is a map of {key,value} pairs.
+                            A single {key,value} in the matchLabels map is equivalent
+                            to an element of matchExpressions, whose key field is
+                            "key", the operator is "In", and the values array contains
+                            only "value". The requirements are ANDed.
+                          type: object
+                      type: object
+                    type: array
+                required:
+                - namespaceSelectors
+                type: object
+              bucketName:
+                description: BucketName is the name of the object storage bucket.
+                type: string
+              endpoint:
+                description: Endpoint is the object storage address the BucketName
+                  is located at.
+                type: string
+              ignore:
+                description: Ignore overrides the set of excluded patterns in the
+                  .sourceignore format (which is the same as .gitignore). If not provided,
+                  a default will be used, consult the documentation for your version
+                  to find out what those are.
+                type: string
+              insecure:
+                description: Insecure allows connecting to a non-TLS HTTP Endpoint.
+                type: boolean
+              interval:
+                description: Interval at which to check the Endpoint for updates.
+                pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
+                type: string
+              provider:
+                default: generic
+                description: Provider of the object storage bucket. Defaults to 'generic',
+                  which expects an S3 (API) compatible object storage.
+                enum:
+                - generic
+                - aws
+                - gcp
+                - azure
+                type: string
+              region:
+                description: Region of the Endpoint where the BucketName is located
+                  in.
+                type: string
+              secretRef:
+                description: SecretRef specifies the Secret containing authentication
+                  credentials for the Bucket.
+                properties:
+                  name:
+                    description: Name of the referent.
+                    type: string
+                required:
+                - name
+                type: object
+              suspend:
+                description: Suspend tells the controller to suspend the reconciliation
+                  of this Bucket.
+                type: boolean
+              timeout:
+                default: 60s
+                description: Timeout for fetch operations, defaults to 60s.
+                pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m))+$
+                type: string
+            required:
+            - bucketName
+            - endpoint
+            - interval
+            type: object
+          status:
+            default:
+              observedGeneration: -1
+            description: BucketStatus records the observed state of a Bucket.
+            properties:
+              artifact:
+                description: Artifact represents the last successful Bucket reconciliation.
+                properties:
+                  checksum:
+                    description: Checksum is the SHA256 checksum of the Artifact file.
+                    type: string
+                  lastUpdateTime:
+                    description: LastUpdateTime is the timestamp corresponding to
+                      the last update of the Artifact.
+                    format: date-time
+                    type: string
+                  metadata:
+                    additionalProperties:
+                      type: string
+                    description: Metadata holds upstream information such as OCI annotations.
+                    type: object
+                  path:
+                    description: Path is the relative file path of the Artifact. It
+                      can be used to locate the file in the root of the Artifact storage
+                      on the local file system of the controller managing the Source.
+                    type: string
+                  revision:
+                    description: Revision is a human-readable identifier traceable
+                      in the origin source system. It can be a Git commit SHA, Git
+                      tag, a Helm chart version, etc.
+                    type: string
+                  size:
+                    description: Size is the number of bytes in the file.
+                    format: int64
+                    type: integer
+                  url:
+                    description: URL is the HTTP address of the Artifact as exposed
+                      by the controller managing the Source. It can be used to retrieve
+                      the Artifact for consumption, e.g. by another controller applying
+                      the Artifact contents.
+                    type: string
+                required:
+                - path
+                - url
+                type: object
+              conditions:
+                description: Conditions holds the conditions for the Bucket.
+                items:
+                  description: "Condition contains details for one aspect of the current
+                    state of this API Resource. --- This struct is intended for direct
+                    use as an array at the field path .status.conditions.  For example,
+                    \n type FooStatus struct{ // Represents the observations of a
+                    foo's current state. // Known .status.conditions.type are: \"Available\",
+                    \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge
+                    // +listType=map // +listMapKey=type Conditions []metav1.Condition
+                    `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\"
+                    protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields }"
+                  properties:
+                    lastTransitionTime:
+                      description: lastTransitionTime is the last time the condition
+                        transitioned from one status to another. This should be when
+                        the underlying condition changed.  If that is not known, then
+                        using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: message is a human readable message indicating
+                        details about the transition. This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: observedGeneration represents the .metadata.generation
+                        that the condition was set based upon. For instance, if .metadata.generation
+                        is currently 12, but the .status.conditions[x].observedGeneration
+                        is 9, the condition is out of date with respect to the current
+                        state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: reason contains a programmatic identifier indicating
+                        the reason for the condition's last transition. Producers
+                        of specific condition types may define expected values and
+                        meanings for this field, and whether the values are considered
+                        a guaranteed API. The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        --- Many .condition.type values are consistent across resources
+                        like Available, but because arbitrary conditions can be useful
+                        (see .node.status.conditions), the ability to deconflict is
+                        important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              lastHandledReconcileAt:
+                description: LastHandledReconcileAt holds the value of the most recent
+                  reconcile request value, so a change of the annotation value can
+                  be detected.
+                type: string
+              observedGeneration:
+                description: ObservedGeneration is the last observed generation of
+                  the Bucket object.
+                format: int64
+                type: integer
+              observedIgnore:
+                description: ObservedIgnore is the observed exclusion patterns used
+                  for constructing the source artifact.
+                type: string
+              url:
+                description: URL is the dynamic fetch link for the latest Artifact.
+                  It is provided on a "best effort" basis, and using the precise BucketStatus.Artifact
+                  data is recommended.
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -47,9 +560,9 @@ spec:
                   \n Notes: 1. versioning is not supported for map keys 2. key names
                   not supported by Redpanda will lead to failure on start up 3. updating
                   this map requires a manual restart of the Redpanda pods. Please
-                  be aware of sync period when one Redpandais POD is restarted 4.
-                  cannot have keys that conflict with existing struct fields - it
-                  leads to panic \n By default if Replicas is 3 or more and redpanda.default_topic_partitions
+                  be aware of sync period when one Redpanda POD is restarted 4. cannot
+                  have keys that conflict with existing struct fields - it leads to
+                  panic \n By default if Replicas is 3 or more and redpanda.default_topic_partitions
                   is not set default webhook is setting redpanda.default_topic_partitions
                   to 3."
                 type: object
@@ -87,6 +600,13 @@ spec:
                         description: Storage class name - https://kubernetes.io/docs/concepts/storage/storage-classes/
                         type: string
                     type: object
+                  credentialsSource:
+                    description: Determines how to load credentials for archival storage.
+                      Supported values are config_file (default), aws_instance_metadata,
+                      sts, gcp_instance_metadata (see the cloud_storage_credentials_source
+                      property at https://docs.redpanda.com/docs/reference/cluster-properties/).
+                      When using config_file then accessKey and secretKeyRef are mandatory.
+                    type: string
                   disableTLS:
                     description: Disable TLS (can be used in tests)
                     type: boolean
@@ -152,6 +672,14 @@ spec:
               configuration:
                 description: Configuration represent redpanda specific configuration
                 properties:
+                  additionalCommandlineArguments:
+                    additionalProperties:
+                      type: string
+                    description: Additional command line arguments that we pass to
+                      the redpanda binary These are applied last and will override
+                      any other command line arguments that may be defined, including
+                      the ones added when setting `DeveloperMode` to `true`.
+                    type: object
                   adminApi:
                     items:
                       description: AdminAPI configures listener for the Redpanda Admin
@@ -182,6 +710,21 @@ spec:
                               description: Enabled enables the external connectivity
                                 feature
                               type: boolean
+                            endpointTemplate:
+                              description: "EndpointTemplate is a Golang template
+                                string that allows customizing each broker advertised
+                                address. Redpanda uses the format BROKER_ID.SUBDOMAIN:EXTERNAL_KAFKA_API_PORT
+                                by default for advertised addresses. When an EndpointTemplate
+                                is provided, then the BROKER_ID part is replaced with
+                                the endpoint computed from the template. The following
+                                variables are available to the template: - Index:
+                                the Redpanda broker progressive number - HostIP: the
+                                ip address of the Node, as reported in pod status
+                                \n Common template functions from Sprig (http://masterminds.github.io/sprig/)
+                                are also available. The set of available functions
+                                is limited to hermetic functions because template
+                                application needs to be deterministic."
+                              type: string
                             preferredAddressType:
                               description: The preferred address type to be assigned
                                 to the external advertised addresses. The valid types
@@ -194,7 +737,7 @@ spec:
                             subdomain:
                               description: Subdomain can be used to change the behavior
                                 of an advertised KafkaAPI. Each broker advertises
-                                Kafka API as follows BROKER_ID.SUBDOMAIN:EXTERNAL_KAFKA_API_PORT.
+                                Kafka API as follows ENDPOINT.SUBDOMAIN:EXTERNAL_KAFKA_API_PORT.
                                 If Subdomain is empty then each broker advertises
                                 Kafka API as PUBLIC_NODE_IP:EXTERNAL_KAFKA_API_PORT.
                                 If TLS is enabled then this subdomain will be requested
@@ -226,6 +769,11 @@ spec:
                     items:
                       description: KafkaAPI configures listener for the Kafka API
                       properties:
+                        authenticationMethod:
+                          description: 'AuthenticationMethod can enable authentication
+                            method per Kafka listener. Available options are: none,
+                            sasl, mtls_identity. https://docs.redpanda.com/docs/security/authentication/'
+                          type: string
                         external:
                           description: External enables user to expose Redpanda nodes
                             outside of a Kubernetes cluster. For more information
@@ -251,6 +799,21 @@ spec:
                               description: Enabled enables the external connectivity
                                 feature
                               type: boolean
+                            endpointTemplate:
+                              description: "EndpointTemplate is a Golang template
+                                string that allows customizing each broker advertised
+                                address. Redpanda uses the format BROKER_ID.SUBDOMAIN:EXTERNAL_KAFKA_API_PORT
+                                by default for advertised addresses. When an EndpointTemplate
+                                is provided, then the BROKER_ID part is replaced with
+                                the endpoint computed from the template. The following
+                                variables are available to the template: - Index:
+                                the Redpanda broker progressive number - HostIP: the
+                                ip address of the Node, as reported in pod status
+                                \n Common template functions from Sprig (http://masterminds.github.io/sprig/)
+                                are also available. The set of available functions
+                                is limited to hermetic functions because template
+                                application needs to be deterministic."
+                              type: string
                             preferredAddressType:
                               description: The preferred address type to be assigned
                                 to the external advertised addresses. The valid types
@@ -263,7 +826,7 @@ spec:
                             subdomain:
                               description: Subdomain can be used to change the behavior
                                 of an advertised KafkaAPI. Each broker advertises
-                                Kafka API as follows BROKER_ID.SUBDOMAIN:EXTERNAL_KAFKA_API_PORT.
+                                Kafka API as follows ENDPOINT.SUBDOMAIN:EXTERNAL_KAFKA_API_PORT.
                                 If Subdomain is empty then each broker advertises
                                 Kafka API as PUBLIC_NODE_IP:EXTERNAL_KAFKA_API_PORT.
                                 If TLS is enabled then this subdomain will be requested
@@ -359,6 +922,11 @@ spec:
                       description: PandaproxyAPI configures listener for the Pandaproxy
                         API
                       properties:
+                        authenticationMethod:
+                          description: 'AuthenticationMethod can enable authentication
+                            method per pandaproxy listener. Available options are:
+                            none, http_basic.'
+                          type: string
                         external:
                           description: External enables user to expose Redpanda nodes
                             outside of a Kubernetes cluster. For more information
@@ -384,6 +952,39 @@ spec:
                               description: Enabled enables the external connectivity
                                 feature
                               type: boolean
+                            endpointTemplate:
+                              description: "EndpointTemplate is a Golang template
+                                string that allows customizing each broker advertised
+                                address. Redpanda uses the format BROKER_ID.SUBDOMAIN:EXTERNAL_KAFKA_API_PORT
+                                by default for advertised addresses. When an EndpointTemplate
+                                is provided, then the BROKER_ID part is replaced with
+                                the endpoint computed from the template. The following
+                                variables are available to the template: - Index:
+                                the Redpanda broker progressive number - HostIP: the
+                                ip address of the Node, as reported in pod status
+                                \n Common template functions from Sprig (http://masterminds.github.io/sprig/)
+                                are also available. The set of available functions
+                                is limited to hermetic functions because template
+                                application needs to be deterministic."
+                              type: string
+                            ingress:
+                              description: Configures a ingress resource
+                              properties:
+                                annotations:
+                                  additionalProperties:
+                                    type: string
+                                  description: Optional annotations for the generated
+                                    ingress.
+                                  type: object
+                                enabled:
+                                  description: Indicates if ingress is enabled (true
+                                    when unspecified).
+                                  type: boolean
+                                endpoint:
+                                  description: If present, it's appended to the subdomain
+                                    to form the ingress hostname.
+                                  type: string
+                              type: object
                             preferredAddressType:
                               description: The preferred address type to be assigned
                                 to the external advertised addresses. The valid types
@@ -396,7 +997,7 @@ spec:
                             subdomain:
                               description: Subdomain can be used to change the behavior
                                 of an advertised KafkaAPI. Each broker advertises
-                                Kafka API as follows BROKER_ID.SUBDOMAIN:EXTERNAL_KAFKA_API_PORT.
+                                Kafka API as follows ENDPOINT.SUBDOMAIN:EXTERNAL_KAFKA_API_PORT.
                                 If Subdomain is empty then each broker advertises
                                 Kafka API as PUBLIC_NODE_IP:EXTERNAL_KAFKA_API_PORT.
                                 If TLS is enabled then this subdomain will be requested
@@ -408,9 +1009,107 @@ spec:
                         tls:
                           description: Configuration of TLS for Pandaproxy API
                           properties:
+                            clientCACertRef:
+                              description: 'If ClientCACertRef points to a secret
+                                containing the trusted CA certificates. If provided
+                                and RequireClientAuth is true, the operator uses the
+                                certificate in this secret instead of issuing client
+                                certificates. The secret is expected to provide the
+                                following keys: ''ca.crt''.'
+                              properties:
+                                apiGroup:
+                                  description: APIGroup is the group for the resource
+                                    being referenced. If APIGroup is not specified,
+                                    the specified Kind must be in the core API group.
+                                    For any other third-party types, APIGroup is required.
+                                  type: string
+                                kind:
+                                  description: Kind is the type of resource being
+                                    referenced
+                                  type: string
+                                name:
+                                  description: Name is the name of resource being
+                                    referenced
+                                  type: string
+                              required:
+                              - kind
+                              - name
+                              type: object
                             enabled:
                               type: boolean
+                            issuerRef:
+                              description: References cert-manager Issuer or ClusterIssuer.
+                                When provided, this issuer will be used to issue node
+                                certificates. Typically you want to provide the issuer
+                                when a generated self-signed one is not enough and
+                                you need to have a verifiable chain with a proper
+                                CA certificate.
+                              properties:
+                                group:
+                                  description: Group of the resource being referred
+                                    to.
+                                  type: string
+                                kind:
+                                  description: Kind of the resource being referred
+                                    to.
+                                  type: string
+                                name:
+                                  description: Name of the resource being referred
+                                    to.
+                                  type: string
+                              required:
+                              - name
+                              type: object
+                            nodeSecretRef:
+                              description: 'If provided, operator uses certificate
+                                in this secret instead of issuing its own node certificate.
+                                The secret is expected to provide the following keys:
+                                ''ca.crt'', ''tls.key'' and ''tls.crt'' If NodeSecretRef
+                                points to secret in different namespace, operator
+                                will duplicate the secret to the same namespace as
+                                redpanda CRD to be able to mount it to the nodes'
+                              properties:
+                                apiVersion:
+                                  description: API version of the referent.
+                                  type: string
+                                fieldPath:
+                                  description: 'If referring to a piece of an object
+                                    instead of an entire object, this string should
+                                    contain a valid JSON/Go field access statement,
+                                    such as desiredState.manifest.containers[2]. For
+                                    example, if the object reference is to a container
+                                    within a pod, this would take on a value like:
+                                    "spec.containers{name}" (where "name" refers to
+                                    the name of the container that triggered the event)
+                                    or if no container name is specified "spec.containers[2]"
+                                    (container with index 2 in this pod). This syntax
+                                    is chosen only to have some well-defined way of
+                                    referencing a part of an object. TODO: this design
+                                    is not final and this field is subject to change
+                                    in the future.'
+                                  type: string
+                                kind:
+                                  description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                                  type: string
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                  type: string
+                                namespace:
+                                  description: 'Namespace of the referent. More info:
+                                    https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                                  type: string
+                                resourceVersion:
+                                  description: 'Specific resourceVersion to which
+                                    this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                                  type: string
+                                uid:
+                                  description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                                  type: string
+                              type: object
                             requireClientAuth:
+                              description: Enables two-way verification on the server
+                                side. If enabled, all Pandaproxy API clients are required
+                                to have a valid client certificate.
                               type: boolean
                           type: object
                       type: object
@@ -425,6 +1124,11 @@ spec:
                     description: SchemaRegistryAPI configures the schema registry
                       API
                     properties:
+                      authenticationMethod:
+                        description: 'AuthenticationMethod can enable authentication
+                          method per schema registry listener. Available options are:
+                          none, http_basic.'
+                        type: string
                       external:
                         description: External enables user to expose Redpanda nodes
                           outside of a Kubernetes cluster. For more information please
@@ -450,6 +1154,25 @@ spec:
                             description: Enabled enables the external connectivity
                               feature
                             type: boolean
+                          endpoint:
+                            description: Indicates the global endpoint that (together
+                              with subdomain), should be advertised for schema registry.
+                            type: string
+                          endpointTemplate:
+                            description: "EndpointTemplate is a Golang template string
+                              that allows customizing each broker advertised address.
+                              Redpanda uses the format BROKER_ID.SUBDOMAIN:EXTERNAL_KAFKA_API_PORT
+                              by default for advertised addresses. When an EndpointTemplate
+                              is provided, then the BROKER_ID part is replaced with
+                              the endpoint computed from the template. The following
+                              variables are available to the template: - Index: the
+                              Redpanda broker progressive number - HostIP: the ip
+                              address of the Node, as reported in pod status \n Common
+                              template functions from Sprig (http://masterminds.github.io/sprig/)
+                              are also available. The set of available functions is
+                              limited to hermetic functions because template application
+                              needs to be deterministic."
+                            type: string
                           preferredAddressType:
                             description: The preferred address type to be assigned
                               to the external advertised addresses. The valid types
@@ -459,10 +1182,14 @@ spec:
                               The default preferred address type is ExternalIP. This
                               option only applies when Subdomain is empty.
                             type: string
+                          staticNodePort:
+                            description: Indicates that the node port for the service
+                              needs not to be generated.
+                            type: boolean
                           subdomain:
                             description: Subdomain can be used to change the behavior
                               of an advertised KafkaAPI. Each broker advertises Kafka
-                              API as follows BROKER_ID.SUBDOMAIN:EXTERNAL_KAFKA_API_PORT.
+                              API as follows ENDPOINT.SUBDOMAIN:EXTERNAL_KAFKA_API_PORT.
                               If Subdomain is empty then each broker advertises Kafka
                               API as PUBLIC_NODE_IP:EXTERNAL_KAFKA_API_PORT. If TLS
                               is enabled then this subdomain will be requested as
@@ -477,6 +1204,29 @@ spec:
                       tls:
                         description: TLS is the configuration for schema registry
                         properties:
+                          clientCACertRef:
+                            description: 'If ClientCACertRef points to a secret containing
+                              the trusted CA certificates. If provided and RequireClientAuth
+                              is true, the operator uses the certificate in this secret
+                              instead of issuing client certificates. The secret is
+                              expected to provide the following keys: ''ca.crt''.'
+                            properties:
+                              apiGroup:
+                                description: APIGroup is the group for the resource
+                                  being referenced. If APIGroup is not specified,
+                                  the specified Kind must be in the core API group.
+                                  For any other third-party types, APIGroup is required.
+                                type: string
+                              kind:
+                                description: Kind is the type of resource being referenced
+                                type: string
+                              name:
+                                description: Name is the name of resource being referenced
+                                type: string
+                            required:
+                            - kind
+                            - name
+                            type: object
                           enabled:
                             type: boolean
                           issuerRef:
@@ -559,11 +1309,39 @@ spec:
                   fully-qualified DNS name. http://www.dns-sd.org/trailingdotsindomainnames.html
                 type: boolean
               enableSasl:
-                description: SASL enablement flag
+                description: 'SASL enablement flag Deprecated: replaced by "kafkaEnableAuthorization"'
                 type: boolean
               image:
                 description: Image is the fully qualified name of the Redpanda container
                 type: string
+              initialValidationForVolume:
+                description: 'When InitialValidationForVolume is enabled the mounted
+                  Redpanda data folder will be checked if: - it is dir - it has XFS
+                  file system - it can create test file and delete it'
+                type: boolean
+              kafkaEnableAuthorization:
+                description: "Enable authorization for Kafka connections. Values are:
+                  \n - `nil`: Ignored. Authorization is enabled with `enable_sasl:
+                  true` \n - `true`: authorization is required \n - `false`: authorization
+                  is disabled; \n See also `enableSasl` and `configuration.kafkaApi[].authenticationMethod`"
+                type: boolean
+              licenseRef:
+                description: If key is not provided in the SecretRef, Secret data
+                  should have key "license"
+                properties:
+                  key:
+                    description: Key in Secret data to get value from
+                    type: string
+                  name:
+                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                    type: string
+                  namespace:
+                    description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                    type: string
+                required:
+                - name
+                - namespace
+                type: object
               nodeSelector:
                 additionalProperties:
                   type: string
@@ -615,6 +1393,26 @@ spec:
                   amount of resources assigned to these containers will be required
                   on the cluster on top of the resources defined here
                 properties:
+                  claims:
+                    description: "Claims lists the names of resources, defined in
+                      spec.resourceClaims, that are used by this container. \n This
+                      is an alpha field and requires enabling the DynamicResourceAllocation
+                      feature gate. \n This field is immutable."
+                    items:
+                      description: ResourceClaim references one entry in PodSpec.ResourceClaims.
+                      properties:
+                        name:
+                          description: Name must match the name of one entry in pod.spec.resourceClaims
+                            of the Pod where this field is used. It makes that resource
+                            available inside a container.
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    type: array
+                    x-kubernetes-list-map-keys:
+                    - name
+                    x-kubernetes-list-type: map
                   limits:
                     additionalProperties:
                       anyOf:
@@ -657,7 +1455,31 @@ spec:
                       and postStart hooks that force nodes to enter maintenance mode
                       when stopping and exit maintenance mode when up again
                     type: boolean
+                  underReplicatedPartitionThreshold:
+                    description: "UnderReplicatedPartitionThreshold controls when
+                      rolling update will continue with restarts. The procedure can
+                      be described as follows: \n 1. Rolling update checks if Pod
+                      specification needs to be replaced and deletes it 2. Deleted
+                      Redpanda Pod is put into maintenance mode (postStart hook will
+                      disable    maintenance mode when new Pod starts) 3. Rolling
+                      update waits for Pod to be in Ready state 4. Rolling update
+                      checks if cluster is in healthy state 5. Rolling update checks
+                      if restarted Redpanda Pod admin API Ready endpoint returns HTTP
+                      200 response 6. Using UnderReplicatedPartitionThreshold each
+                      under replicated partition metric is compared with the threshold
+                      7. Rolling update moves to the next Redpanda pod \n The metric
+                      `vectorized_cluster_partition_under_replicated_replicas` is
+                      used in the comparison \n Mentioned metrics has the following
+                      help description: `vectorized_cluster_partition_under_replicated_replicas`
+                      Number of under replicated replicas \n By default, the UnderReplicatedPartitionThreshold
+                      will be 0, which means all partitions needs to catch up without
+                      any lag."
+                    type: integer
                 type: object
+              serviceAccount:
+                description: The name of the ServiceAccount to be used by the Redpanda
+                  pods
+                type: string
               sidecars:
                 description: Sidecars is list of sidecars run alongside redpanda container
                 properties:
@@ -674,6 +1496,28 @@ spec:
                           for the container running this sidecar. For the default
                           sidecars this is defaulted
                         properties:
+                          claims:
+                            description: "Claims lists the names of resources, defined
+                              in spec.resourceClaims, that are used by this container.
+                              \n This is an alpha field and requires enabling the
+                              DynamicResourceAllocation feature gate. \n This field
+                              is immutable."
+                            items:
+                              description: ResourceClaim references one entry in PodSpec.ResourceClaims.
+                              properties:
+                                name:
+                                  description: Name must match the name of one entry
+                                    in pod.spec.resourceClaims of the Pod where this
+                                    field is used. It makes that resource available
+                                    inside a container.
+                                  type: string
+                              required:
+                              - name
+                              type: object
+                            type: array
+                            x-kubernetes-list-map-keys:
+                            - name
+                            x-kubernetes-list-type: map
                           limits:
                             additionalProperties:
                               anyOf:
@@ -806,6 +1650,16 @@ spec:
                   - type
                   type: object
                 type: array
+              currentReplicas:
+                description: CurrentReplicas is the number of Pods that the controller
+                  currently wants to run for the cluster.
+                format: int32
+                type: integer
+              decommissioningNode:
+                description: Indicates that a node is currently being decommissioned
+                  from the cluster and provides its ordinal number
+                format: int32
+                type: integer
               nodes:
                 description: Nodes of the provisioned redpanda nodes
                 properties:
@@ -908,8 +1762,14 @@ spec:
                         type: string
                     type: object
                 type: object
+              readyReplicas:
+                description: ReadyReplicas is the number of Pods belonging to the
+                  cluster that have a Ready Condition.
+                format: int32
+                type: integer
               replicas:
-                description: Replicas show how many nodes are working in the cluster
+                description: Replicas show how many nodes have been created for the
+                  cluster
                 format: int32
                 type: integer
               restarting:
@@ -923,6 +1783,7413 @@ spec:
               version:
                 description: Current version of the cluster.
                 type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.4.1
+  creationTimestamp: null
+  name: consoles.redpanda.vectorized.io
+spec:
+  group: redpanda.vectorized.io
+  names:
+    kind: Console
+    listKind: ConsoleList
+    plural: consoles
+    singular: console
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: Console is the Schema for the consoles API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: ConsoleSpec defines the desired state of Console Most of
+              the fields here are copied from Console config REF https://github.com/redpanda-data/console/blob/master/backend/pkg/api/config.go
+            properties:
+              cloud:
+                description: Cloud contains configurations for Redpanda cloud. If
+                  you're running a self-hosted installation, you can ignore this
+                properties:
+                  prometheusEndpoint:
+                    description: PrometheusEndpointConfig configures the Prometheus
+                      endpoint that shall be exposed in Redpanda Cloud so that users
+                      can scrape this URL to collect their dataplane's metrics in
+                      their own time-series database.
+                    properties:
+                      basicAuth:
+                        description: BasicAuthConfig are credentials that will be
+                          required by the user in order to scrape the endpoint
+                        properties:
+                          passwordRef:
+                            description: SecretKeyRef contains enough information
+                              to inspect or modify the referred Secret data REF https://pkg.go.dev/k8s.io/api/core/v1#ObjectReference
+                            properties:
+                              key:
+                                description: Key in Secret data to get value from
+                                type: string
+                              name:
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                type: string
+                              namespace:
+                                description: 'Namespace of the referent. More info:
+                                  https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                                type: string
+                            required:
+                            - name
+                            - namespace
+                            type: object
+                          username:
+                            type: string
+                        required:
+                        - passwordRef
+                        - username
+                        type: object
+                      enabled:
+                        type: boolean
+                      prometheus:
+                        description: PrometheusConfig is configuration of prometheus
+                          instance
+                        properties:
+                          address:
+                            description: Address to Prometheus endpoint
+                            type: string
+                          jobs:
+                            description: Jobs is the list of Prometheus Jobs that
+                              we want to discover so that we can then scrape the discovered
+                              targets ourselves.
+                            items:
+                              description: PrometheusScraperJobConfig is the configuration
+                                object that determines what Prometheus targets we
+                                should scrape.
+                              properties:
+                                jobName:
+                                  description: JobName refers to the Prometheus job
+                                    name whose discovered targets we want to scrape
+                                  type: string
+                                keepLabels:
+                                  description: KeepLabels is a list of label keys
+                                    that are added by Prometheus when scraping the
+                                    target and should remain for all metrics as exposed
+                                    to the Prometheus endpoint.
+                                  items:
+                                    type: string
+                                  type: array
+                              required:
+                              - jobName
+                              - keepLabels
+                              type: object
+                            type: array
+                          targetRefreshInterval:
+                            default: 10s
+                            type: string
+                        required:
+                        - address
+                        - jobs
+                        type: object
+                      responseCacheDuration:
+                        default: 1s
+                        format: duration
+                        type: string
+                    required:
+                    - enabled
+                    - prometheus
+                    type: object
+                required:
+                - prometheusEndpoint
+                type: object
+              clusterRef:
+                description: The referenced Redpanda Cluster
+                properties:
+                  name:
+                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                    type: string
+                  namespace:
+                    description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                    type: string
+                required:
+                - name
+                - namespace
+                type: object
+              connect:
+                description: Connect defines configurable fields for Kafka Connect
+                properties:
+                  clusters:
+                    items:
+                      description: ConnectCluster defines configurable fields for
+                        the Kafka Connect cluster
+                      properties:
+                        basicAuthRef:
+                          description: BasicAuthRef configures basic auth credentials
+                            referenced by Secret Expects to have keys "username",
+                            "password"
+                          properties:
+                            apiVersion:
+                              description: API version of the referent.
+                              type: string
+                            fieldPath:
+                              description: 'If referring to a piece of an object instead
+                                of an entire object, this string should contain a
+                                valid JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                                For example, if the object reference is to a container
+                                within a pod, this would take on a value like: "spec.containers{name}"
+                                (where "name" refers to the name of the container
+                                that triggered the event) or if no container name
+                                is specified "spec.containers[2]" (container with
+                                index 2 in this pod). This syntax is chosen only to
+                                have some well-defined way of referencing a part of
+                                an object. TODO: this design is not final and this
+                                field is subject to change in the future.'
+                              type: string
+                            kind:
+                              description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                              type: string
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                              type: string
+                            namespace:
+                              description: 'Namespace of the referent. More info:
+                                https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                              type: string
+                            resourceVersion:
+                              description: 'Specific resourceVersion to which this
+                                reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                              type: string
+                            uid:
+                              description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                              type: string
+                          type: object
+                        name:
+                          type: string
+                        tls:
+                          description: TLS configures mTLS auth
+                          properties:
+                            enabled:
+                              type: boolean
+                            insecureSkipTlsVerify:
+                              type: boolean
+                            secretKeyRef:
+                              description: SecretKeyRef configures certificate used
+                                for mTLS auth referenced by Secret Expects to have
+                                keys "tls.crt", "tls.key", "ca.crt"
+                              properties:
+                                apiVersion:
+                                  description: API version of the referent.
+                                  type: string
+                                fieldPath:
+                                  description: 'If referring to a piece of an object
+                                    instead of an entire object, this string should
+                                    contain a valid JSON/Go field access statement,
+                                    such as desiredState.manifest.containers[2]. For
+                                    example, if the object reference is to a container
+                                    within a pod, this would take on a value like:
+                                    "spec.containers{name}" (where "name" refers to
+                                    the name of the container that triggered the event)
+                                    or if no container name is specified "spec.containers[2]"
+                                    (container with index 2 in this pod). This syntax
+                                    is chosen only to have some well-defined way of
+                                    referencing a part of an object. TODO: this design
+                                    is not final and this field is subject to change
+                                    in the future.'
+                                  type: string
+                                kind:
+                                  description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                                  type: string
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                  type: string
+                                namespace:
+                                  description: 'Namespace of the referent. More info:
+                                    https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                                  type: string
+                                resourceVersion:
+                                  description: 'Specific resourceVersion to which
+                                    this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                                  type: string
+                                uid:
+                                  description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                                  type: string
+                              type: object
+                          type: object
+                        tokenRef:
+                          description: TokenRef configures token header auth referenced
+                            by Secret Expects to have key "token"
+                          properties:
+                            apiVersion:
+                              description: API version of the referent.
+                              type: string
+                            fieldPath:
+                              description: 'If referring to a piece of an object instead
+                                of an entire object, this string should contain a
+                                valid JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                                For example, if the object reference is to a container
+                                within a pod, this would take on a value like: "spec.containers{name}"
+                                (where "name" refers to the name of the container
+                                that triggered the event) or if no container name
+                                is specified "spec.containers[2]" (container with
+                                index 2 in this pod). This syntax is chosen only to
+                                have some well-defined way of referencing a part of
+                                an object. TODO: this design is not final and this
+                                field is subject to change in the future.'
+                              type: string
+                            kind:
+                              description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                              type: string
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                              type: string
+                            namespace:
+                              description: 'Namespace of the referent. More info:
+                                https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                              type: string
+                            resourceVersion:
+                              description: 'Specific resourceVersion to which this
+                                reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                              type: string
+                            uid:
+                              description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                              type: string
+                          type: object
+                        url:
+                          type: string
+                      required:
+                      - name
+                      - url
+                      type: object
+                    type: array
+                  connectTimeout:
+                    default: 15s
+                    format: duration
+                    type: string
+                  enabled:
+                    type: boolean
+                  readTimeout:
+                    default: 60s
+                    format: duration
+                    type: string
+                  requestTimeout:
+                    default: 6s
+                    format: duration
+                    type: string
+                type: object
+              deployment:
+                description: Deployment defines configurable fields for the Console
+                  Deployment resource
+                properties:
+                  image:
+                    type: string
+                  maxSurge:
+                    default: 1
+                    format: int32
+                    type: integer
+                  maxUnavailable:
+                    default: 0
+                    format: int32
+                    type: integer
+                  replicas:
+                    default: 1
+                    format: int32
+                    type: integer
+                required:
+                - image
+                type: object
+              enterprise:
+                description: Enterprise defines configurable fields for features that
+                  require license
+                properties:
+                  rbac:
+                    description: Console uses role-based access control (RBAC) to
+                      restrict system access to authorized users
+                    properties:
+                      enabled:
+                        type: boolean
+                      roleBindingsRef:
+                        description: RoleBindingsRef is the ConfigMap that contains
+                          the RBAC file The ConfigMap should contain "rbac.yaml" key
+                        properties:
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              TODO: Add other useful fields. apiVersion, kind, uid?'
+                            type: string
+                        type: object
+                    required:
+                    - enabled
+                    - roleBindingsRef
+                    type: object
+                required:
+                - rbac
+                type: object
+              ingress:
+                description: Ingress contains configuration for the Console ingress.
+                properties:
+                  annotations:
+                    additionalProperties:
+                      type: string
+                    description: Optional annotations for the generated ingress.
+                    type: object
+                  enabled:
+                    description: Indicates if ingress is enabled (true when unspecified).
+                    type: boolean
+                  endpoint:
+                    description: If present, it's appended to the subdomain to form
+                      the ingress hostname.
+                    type: string
+                type: object
+              licenseRef:
+                description: If you don't provide an enterprise license, Console ignores
+                  configurations for enterprise features REF https://docs.redpanda.com/docs/console/reference/config/
+                  If key is not provided in the SecretRef, Secret data should have
+                  key "license"
+                properties:
+                  key:
+                    description: Key in Secret data to get value from
+                    type: string
+                  name:
+                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                    type: string
+                  namespace:
+                    description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                    type: string
+                required:
+                - name
+                - namespace
+                type: object
+              login:
+                description: Login contains all configurations in order to protect
+                  Console with a login screen Configure one or more of the below identity
+                  providers in order to support SSO This feature requires an Enterprise
+                  license REF https://docs.redpanda.com/docs/console/single-sign-on/identity-providers/google/
+                properties:
+                  enabled:
+                    type: boolean
+                  google:
+                    description: EnterpriseLoginGoogle defines configurable fields
+                      for Google provider
+                    properties:
+                      clientCredentialsRef:
+                        description: ClientCredentials is the Secret that contains
+                          SSO credentials The Secret should contain keys "clientId",
+                          "clientSecret"
+                        properties:
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                            type: string
+                          namespace:
+                            description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                            type: string
+                        required:
+                        - name
+                        - namespace
+                        type: object
+                      directory:
+                        description: Use Google groups in your RBAC role bindings.
+                        properties:
+                          serviceAccountRef:
+                            description: ServiceAccountRef is the ConfigMap that contains
+                              the Google Service Account json The ConfigMap should
+                              contain "sa.json" key
+                            properties:
+                              name:
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  TODO: Add other useful fields. apiVersion, kind,
+                                  uid?'
+                                type: string
+                            type: object
+                          targetPrincipal:
+                            description: TargetPrincipal is the user that shall be
+                              impersonated by the service account
+                            type: string
+                        required:
+                        - serviceAccountRef
+                        - targetPrincipal
+                        type: object
+                      enabled:
+                        type: boolean
+                    required:
+                    - clientCredentialsRef
+                    - enabled
+                    type: object
+                  jwtSecretRef:
+                    description: JWTSecret is the Secret that is used to sign and
+                      encrypt the JSON Web tokens that are used by the backend for
+                      session management If not provided, the default key is "jwt"
+                    properties:
+                      key:
+                        description: Key in Secret data to get value from
+                        type: string
+                      name:
+                        description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                        type: string
+                      namespace:
+                        description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                        type: string
+                    required:
+                    - name
+                    - namespace
+                    type: object
+                  redpandaCloud:
+                    description: EnterpriseLoginRedpandaCloud defines configurable
+                      fields for RedpandaCloud SSO provider
+                    properties:
+                      allowedOrigins:
+                        description: AllowedOrigins indicates if response is allowed
+                          from given origin
+                        items:
+                          type: string
+                        type: array
+                      audience:
+                        description: Audience is the domain where this auth is intended
+                          for
+                        type: string
+                      domain:
+                        description: Domain is the domain of the auth server
+                        type: string
+                      enabled:
+                        type: boolean
+                    required:
+                    - audience
+                    - domain
+                    - enabled
+                    type: object
+                required:
+                - enabled
+                - jwtSecretRef
+                type: object
+              metricsNamespace:
+                default: console
+                description: Prefix for all exported prometheus metrics
+                type: string
+              redpanda:
+                description: Redpanda contains configurations that are Redpanda specific
+                properties:
+                  adminApi:
+                    description: RedpandaAdmin defines API configuration that enables
+                      additional features that are Redpanda specific
+                    properties:
+                      enabled:
+                        type: boolean
+                    required:
+                    - enabled
+                    type: object
+                type: object
+              schema:
+                description: Schema defines configurable fields for Schema Registry
+                properties:
+                  enabled:
+                    type: boolean
+                  useSchemaRegistryCA:
+                    description: Indication on whether to use the schema registry
+                      CA as trust when connecting to the schema registry. If not set,
+                      the public CAs will be used.
+                    type: boolean
+                required:
+                - enabled
+                type: object
+              secretStore:
+                description: SecretStore contains the configuration for the cloud
+                  provider secret manager
+                properties:
+                  awsSecretManager:
+                    description: SecretManagerAWS is the configuration object for
+                      using Amazon's secret manager.
+                    properties:
+                      AWSCredentialsRef:
+                        description: AWSCredentialsRef refers to Kubernetes secret
+                          where AWS access key id and secret access key is taken and
+                          used as environments variable
+                        properties:
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              TODO: Add other useful fields. apiVersion, kind, uid?'
+                            type: string
+                        type: object
+                      enabled:
+                        description: Enabled is whether AWS secret manager is enabled.
+                          Only one store can be enabled at a time.
+                        type: boolean
+                      kmsKeyId:
+                        description: "KmsKeyID is the ARN, key ID, or alias of the
+                          KMS key that Secrets Manager uses to encrypt the secret
+                          value in the secret. \n To use a KMS key in a different
+                          account, use the key ARN or the alias ARN. \n If you don't
+                          specify this value, then Secrets Manager uses the key aws/secretsmanager.
+                          If that key doesn't yet exist, then Secrets Manager creates
+                          it for you automatically the first time it encrypts the
+                          secret value. \n If the secret is in a different Amazon
+                          Web Services account from the credentials calling the API,
+                          then you can't use aws/secretsmanager to encrypt the secret,
+                          and you must create and use a customer managed KMS key."
+                        type: string
+                      region:
+                        description: Region in which service is deployed so that related
+                          resources like secrets are put to the same region
+                        type: string
+                      serviceAccountRoleARNAnnotation:
+                        description: ServiceAccountRoleARNAnnotation will be included
+                          in the Service Account definition. That Kubernetes Service
+                          Account will be used in Kubernetes Deployment Spec of Console
+                          Ref https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html
+                        type: string
+                      tags:
+                        additionalProperties:
+                          type: string
+                        description: "Tags is a list of tags to attach to the secret.
+                          Each tag is a key and value a pair of strings in a JSON
+                          text string, for example: \n [{\"Key\":\"CostCenter\",\"Value\":\"12345\"},{\"Key\":\"environment\",\"Value\":\"production\"}]
+                          \n Secrets Manager tag key names are case sensitive. A tag
+                          with the key \"ABC\" is a different tag from one with key
+                          \"abc\". \n Tags can be used for permissions, so that you
+                          can namespace your secrets within a single secret store.
+                          Console will also only allow the deletion of secrets that
+                          posses the configured tags. Tags default to: \"owner\":
+                          \"console\""
+                        type: object
+                    required:
+                    - enabled
+                    - region
+                    type: object
+                  enabled:
+                    type: boolean
+                  gcpSecretManager:
+                    description: SecretManagerGCP is the configuration object for
+                      using Google Cloud's secret manager.
+                    properties:
+                      credentialsSecretRef:
+                        description: CredentialsSecretRef points to Kubernetes secret
+                          where service account will be mounted to Console and used
+                          to authenticate again GCP API.
+                        properties:
+                          key:
+                            description: Key in Secret data to get value from
+                            type: string
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                            type: string
+                          namespace:
+                            description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                            type: string
+                        required:
+                        - name
+                        - namespace
+                        type: object
+                      enabled:
+                        description: Enabled is whether GCP secret manager is enabled.
+                          Only one store can be enabled at a time.
+                        type: boolean
+                      labels:
+                        additionalProperties:
+                          type: string
+                        description: "Labels help you to organize your project, add
+                          arbitrary labels as key/value pairs to your resources. Use
+                          labels to indicate different environments, services, teams,
+                          and so on. Console may use additional labels for each secret.
+                          \n Use a label with key \"owner\" to namespace secrets within
+                          a secret manager. This label will always be set for the
+                          creation and listing of all secrets. If you change the value
+                          after secrets have been created, Console will no longer
+                          return them and consider them as managed by another application.
+                          The owner label is optional but recommended. \n Labels default
+                          to: \"owner\": \"console\""
+                        type: object
+                      projectId:
+                        description: ProjectID is the GCP project in which to store
+                          the secrets.
+                        type: string
+                      serviceAccountNameAnnotation:
+                        description: ServiceAccountNameAnnotation will be included
+                          in the Service Account definition. That Kubernetes Service
+                          Account will be used in Kubernetes Deployment Spec of Console
+                          Ref https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity
+                        type: string
+                    required:
+                    - enabled
+                    - projectId
+                    type: object
+                  kafkaConnect:
+                    description: SecretStoreKafkaConnect is a configuration block
+                      that specifies what configured Kafka connect clusters support
+                      loading secrets from the configured secret store. The frontend
+                      will only store sensitive connector configurations in the secret
+                      store if the respective kafka connect cluster is listed in this
+                      configuration.
+                    properties:
+                      clusters:
+                        description: Clusters is the list of Kafka connect clusters
+                          which the secret store shall be used for.
+                        items:
+                          description: SecretStoreKafkaConnectCluster configures the
+                            Kafka connect clusters that support loading secrets from
+                            the configured secret store.
+                          properties:
+                            name:
+                              description: Name refers to the Kafka connect cluster
+                                name that has been given in the connect configuration.
+                                This name must match some cluster name or the configuration
+                                will be rejected.
+                              type: string
+                            secretNamePrefixAppend:
+                              description: "SecretNamePrefixAppend is an optional
+                                string that shall be appended to the global secretNamePrefix.
+                                This config is helpful if you want to use a specific
+                                prefix for secrets belonging to this Kafka connect
+                                cluster. You may want to do this if you want to restrict
+                                the permissions for the kafka connect workers reading
+                                these secrets. \n Example: secretstore.secretNamePrefix
+                                is set to: \"redpanda/prod/\" secretstore.kafkaConnect.clusters.dwh.secretNamePrefixAppend
+                                is set to: \"dwh/\" => Secrets will be created with
+                                the prefix \"redpanda/prod/dwh/\" so that you can
+                                apply special iam permissions in your cloud account."
+                              type: string
+                          required:
+                          - name
+                          - secretNamePrefixAppend
+                          type: object
+                        type: array
+                      enabled:
+                        type: boolean
+                    required:
+                    - clusters
+                    - enabled
+                    type: object
+                  secretNamePrefix:
+                    description: "SecretNamePrefix is the prefix that shall be used
+                      for each secret name that will be stored. The prefix is used
+                      for namespacing your secrets, so that one secret store can be
+                      used by multiple tenants. For AWS it's common to use a path-like
+                      structure whereas GCP does not allow slashes. \n Examples: AWS:
+                      redpanda/analytics/prod/console/ GCP: redpanda-analytics-prod-console-
+                      \n Changing this prefix won't let you access secrets created
+                      under a different prefix."
+                    type: string
+                required:
+                - enabled
+                - secretNamePrefix
+                type: object
+              serveFrontend:
+                default: true
+                description: Only relevant for developers, who might want to run the
+                  frontend separately
+                type: boolean
+              server:
+                description: Server is the Console app HTTP server config REF https://github.com/cloudhut/common/blob/b601d681e8599cee4255899def813142c0218e8b/rest/config.go
+                properties:
+                  basePath:
+                    description: Sets the subpath (root prefix) under which Kowl is
+                      reachable. If you want to host Kowl under 'your.domain.com/kowl/'
+                      you'd set the base path to 'kowl/'. The default is an empty
+                      string which makes Kowl reachable under just 'domain.com/'.
+                      When using this setting (or letting the 'X-Forwarded-Prefix'
+                      header set it for you) remember to either leave 'strip-prefix'
+                      enabled, or use a proxy that can strip the base-path/prefix
+                      before it reaches Kowl.
+                    type: string
+                  compressionLevel:
+                    default: 4
+                    description: 'Compression level applied to all http responses.
+                      Valid values are: 0-9 (0=completely disable compression middleware,
+                      1=weakest compression, 9=best compression)'
+                    type: integer
+                  gracefulShutdownTimeout:
+                    default: 30s
+                    description: Timeout for graceful shutdowns
+                    format: duration
+                    type: string
+                  idleTimeout:
+                    default: 30s
+                    description: Idle timeout for HTTP server
+                    format: duration
+                    type: string
+                  listenAddress:
+                    description: HTTP server listen address
+                    type: string
+                  listenPort:
+                    default: 8080
+                    description: HTTP server listen port
+                    type: integer
+                  readTimeout:
+                    default: 30s
+                    description: Read timeout for HTTP server
+                    format: duration
+                    type: string
+                  setBasePathFromXForwardedPrefix:
+                    default: true
+                    description: server.set-base-path-from-x-forwarded-prefix", true,
+                      "When set to true, Kowl will use the 'X-Forwarded-Prefix' header
+                      as the base path. (When enabled the 'base-path' setting won't
+                      be used)
+                    type: boolean
+                  stripPrefix:
+                    default: true
+                    description: If a base-path is set (either by the 'base-path'
+                      setting, or by the 'X-Forwarded-Prefix' header), they will be
+                      removed from the request url. You probably want to leave this
+                      enabled, unless you are using a proxy that can remove the prefix
+                      automatically (like Traefik's 'StripPrefix' option)
+                    type: boolean
+                  writeTimeout:
+                    default: 30s
+                    description: Write timeout for HTTP server
+                    format: duration
+                    type: string
+                type: object
+              serviceAccount:
+                description: The name of the ServiceAccount to be used by the Redpanda
+                  pods
+                type: string
+            required:
+            - clusterRef
+            - connect
+            - deployment
+            - schema
+            type: object
+          status:
+            description: ConsoleStatus defines the observed state of Console
+            properties:
+              availableReplicas:
+                description: Total number of available pods (ready for at least minReadySeconds)
+                  targeted by this deployment.
+                format: int32
+                type: integer
+              clusterGeneration:
+                description: The generation of the Repanda cluster
+                format: int64
+                type: integer
+              configMapRef:
+                description: The ConfigMap used by Console This is used to pass the
+                  ConfigMap used to mount in the Deployment Resource since Ensure()
+                  only returns error
+                properties:
+                  apiVersion:
+                    description: API version of the referent.
+                    type: string
+                  fieldPath:
+                    description: 'If referring to a piece of an object instead of
+                      an entire object, this string should contain a valid JSON/Go
+                      field access statement, such as desiredState.manifest.containers[2].
+                      For example, if the object reference is to a container within
+                      a pod, this would take on a value like: "spec.containers{name}"
+                      (where "name" refers to the name of the container that triggered
+                      the event) or if no container name is specified "spec.containers[2]"
+                      (container with index 2 in this pod). This syntax is chosen
+                      only to have some well-defined way of referencing a part of
+                      an object. TODO: this design is not final and this field is
+                      subject to change in the future.'
+                    type: string
+                  kind:
+                    description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                    type: string
+                  name:
+                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                    type: string
+                  namespace:
+                    description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                    type: string
+                  resourceVersion:
+                    description: 'Specific resourceVersion to which this reference
+                      is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                    type: string
+                  uid:
+                    description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                    type: string
+                type: object
+              connectivity:
+                description: Connectivity defines internal/external hosts
+                properties:
+                  external:
+                    type: string
+                  internal:
+                    type: string
+                type: object
+              observedGeneration:
+                description: The generation observed by the controller
+                format: int64
+                type: integer
+              readyReplicas:
+                description: readyReplicas is the number of pods targeted by this
+                  Deployment with a Ready Condition.
+                format: int32
+                type: integer
+              replicas:
+                description: Total number of non-terminated pods targeted by this
+                  deployment (their labels match the selector).
+                format: int32
+                type: integer
+              unavailableReplicas:
+                description: Total number of unavailable pods targeted by this deployment.
+                  This is the total number of pods that are still required for the
+                  deployment to have 100% available capacity. They may either be pods
+                  that are running but not yet available or pods that still have not
+                  been created.
+                format: int32
+                type: integer
+              updatedReplicas:
+                description: Total number of non-terminated pods targeted by this
+                  deployment that have the desired template spec.
+                format: int32
+                type: integer
+              version:
+                description: Current version of the cluster.
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.8.0
+  creationTimestamp: null
+  name: gitrepositories.source.toolkit.fluxcd.io
+spec:
+  group: source.toolkit.fluxcd.io
+  names:
+    kind: GitRepository
+    listKind: GitRepositoryList
+    plural: gitrepositories
+    shortNames:
+    - gitrepo
+    singular: gitrepository
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .spec.url
+      name: URL
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Ready")].message
+      name: Status
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: GitRepository is the Schema for the gitrepositories API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: GitRepositorySpec defines the desired state of a Git repository.
+            properties:
+              accessFrom:
+                description: AccessFrom defines an Access Control List for allowing
+                  cross-namespace references to this object.
+                properties:
+                  namespaceSelectors:
+                    description: NamespaceSelectors is the list of namespace selectors
+                      to which this ACL applies. Items in this list are evaluated
+                      using a logical OR operation.
+                    items:
+                      description: NamespaceSelector selects the namespaces to which
+                        this ACL applies. An empty map of MatchLabels matches all
+                        namespaces in a cluster.
+                      properties:
+                        matchLabels:
+                          additionalProperties:
+                            type: string
+                          description: MatchLabels is a map of {key,value} pairs.
+                            A single {key,value} in the matchLabels map is equivalent
+                            to an element of matchExpressions, whose key field is
+                            "key", the operator is "In", and the values array contains
+                            only "value". The requirements are ANDed.
+                          type: object
+                      type: object
+                    type: array
+                required:
+                - namespaceSelectors
+                type: object
+              gitImplementation:
+                default: go-git
+                description: Determines which git client library to use. Defaults
+                  to go-git, valid values are ('go-git', 'libgit2').
+                enum:
+                - go-git
+                - libgit2
+                type: string
+              ignore:
+                description: Ignore overrides the set of excluded patterns in the
+                  .sourceignore format (which is the same as .gitignore). If not provided,
+                  a default will be used, consult the documentation for your version
+                  to find out what those are.
+                type: string
+              include:
+                description: Extra git repositories to map into the repository
+                items:
+                  description: GitRepositoryInclude defines a source with a from and
+                    to path.
+                  properties:
+                    fromPath:
+                      description: The path to copy contents from, defaults to the
+                        root directory.
+                      type: string
+                    repository:
+                      description: Reference to a GitRepository to include.
+                      properties:
+                        name:
+                          description: Name of the referent.
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    toPath:
+                      description: The path to copy contents to, defaults to the name
+                        of the source ref.
+                      type: string
+                  required:
+                  - repository
+                  type: object
+                type: array
+              interval:
+                description: The interval at which to check for repository updates.
+                type: string
+              recurseSubmodules:
+                description: When enabled, after the clone is created, initializes
+                  all submodules within, using their default settings. This option
+                  is available only when using the 'go-git' GitImplementation.
+                type: boolean
+              ref:
+                description: The Git reference to checkout and monitor for changes,
+                  defaults to master branch.
+                properties:
+                  branch:
+                    description: The Git branch to checkout, defaults to master.
+                    type: string
+                  commit:
+                    description: The Git commit SHA to checkout, if specified Tag
+                      filters will be ignored.
+                    type: string
+                  semver:
+                    description: The Git tag semver expression, takes precedence over
+                      Tag.
+                    type: string
+                  tag:
+                    description: The Git tag to checkout, takes precedence over Branch.
+                    type: string
+                type: object
+              secretRef:
+                description: The secret name containing the Git credentials. For HTTPS
+                  repositories the secret must contain username and password fields.
+                  For SSH repositories the secret must contain identity and known_hosts
+                  fields.
+                properties:
+                  name:
+                    description: Name of the referent.
+                    type: string
+                required:
+                - name
+                type: object
+              suspend:
+                description: This flag tells the controller to suspend the reconciliation
+                  of this source.
+                type: boolean
+              timeout:
+                default: 60s
+                description: The timeout for remote Git operations like cloning, defaults
+                  to 60s.
+                type: string
+              url:
+                description: The repository URL, can be a HTTP/S or SSH address.
+                pattern: ^(http|https|ssh)://.*$
+                type: string
+              verify:
+                description: Verify OpenPGP signature for the Git commit HEAD points
+                  to.
+                properties:
+                  mode:
+                    description: Mode describes what git object should be verified,
+                      currently ('head').
+                    enum:
+                    - head
+                    type: string
+                  secretRef:
+                    description: The secret name containing the public keys of all
+                      trusted Git authors.
+                    properties:
+                      name:
+                        description: Name of the referent.
+                        type: string
+                    required:
+                    - name
+                    type: object
+                required:
+                - mode
+                type: object
+            required:
+            - interval
+            - url
+            type: object
+          status:
+            default:
+              observedGeneration: -1
+            description: GitRepositoryStatus defines the observed state of a Git repository.
+            properties:
+              artifact:
+                description: Artifact represents the output of the last successful
+                  repository sync.
+                properties:
+                  checksum:
+                    description: Checksum is the SHA256 checksum of the artifact.
+                    type: string
+                  lastUpdateTime:
+                    description: LastUpdateTime is the timestamp corresponding to
+                      the last update of this artifact.
+                    format: date-time
+                    type: string
+                  path:
+                    description: Path is the relative file path of this artifact.
+                    type: string
+                  revision:
+                    description: Revision is a human readable identifier traceable
+                      in the origin source system. It can be a Git commit SHA, Git
+                      tag, a Helm index timestamp, a Helm chart version, etc.
+                    type: string
+                  url:
+                    description: URL is the HTTP address of this artifact.
+                    type: string
+                required:
+                - path
+                - url
+                type: object
+              conditions:
+                description: Conditions holds the conditions for the GitRepository.
+                items:
+                  description: "Condition contains details for one aspect of the current
+                    state of this API Resource. --- This struct is intended for direct
+                    use as an array at the field path .status.conditions.  For example,
+                    \n type FooStatus struct{ // Represents the observations of a
+                    foo's current state. // Known .status.conditions.type are: \"Available\",
+                    \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge
+                    // +listType=map // +listMapKey=type Conditions []metav1.Condition
+                    `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\"
+                    protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields }"
+                  properties:
+                    lastTransitionTime:
+                      description: lastTransitionTime is the last time the condition
+                        transitioned from one status to another. This should be when
+                        the underlying condition changed.  If that is not known, then
+                        using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: message is a human readable message indicating
+                        details about the transition. This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: observedGeneration represents the .metadata.generation
+                        that the condition was set based upon. For instance, if .metadata.generation
+                        is currently 12, but the .status.conditions[x].observedGeneration
+                        is 9, the condition is out of date with respect to the current
+                        state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: reason contains a programmatic identifier indicating
+                        the reason for the condition's last transition. Producers
+                        of specific condition types may define expected values and
+                        meanings for this field, and whether the values are considered
+                        a guaranteed API. The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        --- Many .condition.type values are consistent across resources
+                        like Available, but because arbitrary conditions can be useful
+                        (see .node.status.conditions), the ability to deconflict is
+                        important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              includedArtifacts:
+                description: IncludedArtifacts represents the included artifacts from
+                  the last successful repository sync.
+                items:
+                  description: Artifact represents the output of a source synchronisation.
+                  properties:
+                    checksum:
+                      description: Checksum is the SHA256 checksum of the artifact.
+                      type: string
+                    lastUpdateTime:
+                      description: LastUpdateTime is the timestamp corresponding to
+                        the last update of this artifact.
+                      format: date-time
+                      type: string
+                    path:
+                      description: Path is the relative file path of this artifact.
+                      type: string
+                    revision:
+                      description: Revision is a human readable identifier traceable
+                        in the origin source system. It can be a Git commit SHA, Git
+                        tag, a Helm index timestamp, a Helm chart version, etc.
+                      type: string
+                    url:
+                      description: URL is the HTTP address of this artifact.
+                      type: string
+                  required:
+                  - path
+                  - url
+                  type: object
+                type: array
+              lastHandledReconcileAt:
+                description: LastHandledReconcileAt holds the value of the most recent
+                  reconcile request value, so a change of the annotation value can
+                  be detected.
+                type: string
+              observedGeneration:
+                description: ObservedGeneration is the last observed generation.
+                format: int64
+                type: integer
+              url:
+                description: URL is the download link for the artifact output of the
+                  last repository sync.
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
+  - additionalPrinterColumns:
+    - jsonPath: .spec.url
+      name: URL
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Ready")].message
+      name: Status
+      type: string
+    name: v1beta2
+    schema:
+      openAPIV3Schema:
+        description: GitRepository is the Schema for the gitrepositories API.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: GitRepositorySpec specifies the required configuration to
+              produce an Artifact for a Git repository.
+            properties:
+              accessFrom:
+                description: 'AccessFrom specifies an Access Control List for allowing
+                  cross-namespace references to this object. NOTE: Not implemented,
+                  provisional as of https://github.com/fluxcd/flux2/pull/2092'
+                properties:
+                  namespaceSelectors:
+                    description: NamespaceSelectors is the list of namespace selectors
+                      to which this ACL applies. Items in this list are evaluated
+                      using a logical OR operation.
+                    items:
+                      description: NamespaceSelector selects the namespaces to which
+                        this ACL applies. An empty map of MatchLabels matches all
+                        namespaces in a cluster.
+                      properties:
+                        matchLabels:
+                          additionalProperties:
+                            type: string
+                          description: MatchLabels is a map of {key,value} pairs.
+                            A single {key,value} in the matchLabels map is equivalent
+                            to an element of matchExpressions, whose key field is
+                            "key", the operator is "In", and the values array contains
+                            only "value". The requirements are ANDed.
+                          type: object
+                      type: object
+                    type: array
+                required:
+                - namespaceSelectors
+                type: object
+              gitImplementation:
+                default: go-git
+                description: GitImplementation specifies which Git client library
+                  implementation to use. Defaults to 'go-git', valid values are ('go-git',
+                  'libgit2').
+                enum:
+                - go-git
+                - libgit2
+                type: string
+              ignore:
+                description: Ignore overrides the set of excluded patterns in the
+                  .sourceignore format (which is the same as .gitignore). If not provided,
+                  a default will be used, consult the documentation for your version
+                  to find out what those are.
+                type: string
+              include:
+                description: Include specifies a list of GitRepository resources which
+                  Artifacts should be included in the Artifact produced for this GitRepository.
+                items:
+                  description: GitRepositoryInclude specifies a local reference to
+                    a GitRepository which Artifact (sub-)contents must be included,
+                    and where they should be placed.
+                  properties:
+                    fromPath:
+                      description: FromPath specifies the path to copy contents from,
+                        defaults to the root of the Artifact.
+                      type: string
+                    repository:
+                      description: GitRepositoryRef specifies the GitRepository which
+                        Artifact contents must be included.
+                      properties:
+                        name:
+                          description: Name of the referent.
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    toPath:
+                      description: ToPath specifies the path to copy contents to,
+                        defaults to the name of the GitRepositoryRef.
+                      type: string
+                  required:
+                  - repository
+                  type: object
+                type: array
+              interval:
+                description: Interval at which to check the GitRepository for updates.
+                pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
+                type: string
+              recurseSubmodules:
+                description: RecurseSubmodules enables the initialization of all submodules
+                  within the GitRepository as cloned from the URL, using their default
+                  settings. This option is available only when using the 'go-git'
+                  GitImplementation.
+                type: boolean
+              ref:
+                description: Reference specifies the Git reference to resolve and
+                  monitor for changes, defaults to the 'master' branch.
+                properties:
+                  branch:
+                    description: "Branch to check out, defaults to 'master' if no
+                      other field is defined. \n When GitRepositorySpec.GitImplementation
+                      is set to 'go-git', a shallow clone of the specified branch
+                      is performed."
+                    type: string
+                  commit:
+                    description: "Commit SHA to check out, takes precedence over all
+                      reference fields. \n When GitRepositorySpec.GitImplementation
+                      is set to 'go-git', this can be combined with Branch to shallow
+                      clone the branch, in which the commit is expected to exist."
+                    type: string
+                  semver:
+                    description: SemVer tag expression to check out, takes precedence
+                      over Tag.
+                    type: string
+                  tag:
+                    description: Tag to check out, takes precedence over Branch.
+                    type: string
+                type: object
+              secretRef:
+                description: SecretRef specifies the Secret containing authentication
+                  credentials for the GitRepository. For HTTPS repositories the Secret
+                  must contain 'username' and 'password' fields. For SSH repositories
+                  the Secret must contain 'identity' and 'known_hosts' fields.
+                properties:
+                  name:
+                    description: Name of the referent.
+                    type: string
+                required:
+                - name
+                type: object
+              suspend:
+                description: Suspend tells the controller to suspend the reconciliation
+                  of this GitRepository.
+                type: boolean
+              timeout:
+                default: 60s
+                description: Timeout for Git operations like cloning, defaults to
+                  60s.
+                pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m))+$
+                type: string
+              url:
+                description: URL specifies the Git repository URL, it can be an HTTP/S
+                  or SSH address.
+                pattern: ^(http|https|ssh)://.*$
+                type: string
+              verify:
+                description: Verification specifies the configuration to verify the
+                  Git commit signature(s).
+                properties:
+                  mode:
+                    description: Mode specifies what Git object should be verified,
+                      currently ('head').
+                    enum:
+                    - head
+                    type: string
+                  secretRef:
+                    description: SecretRef specifies the Secret containing the public
+                      keys of trusted Git authors.
+                    properties:
+                      name:
+                        description: Name of the referent.
+                        type: string
+                    required:
+                    - name
+                    type: object
+                required:
+                - mode
+                type: object
+            required:
+            - interval
+            - url
+            type: object
+          status:
+            default:
+              observedGeneration: -1
+            description: GitRepositoryStatus records the observed state of a Git repository.
+            properties:
+              artifact:
+                description: Artifact represents the last successful GitRepository
+                  reconciliation.
+                properties:
+                  checksum:
+                    description: Checksum is the SHA256 checksum of the Artifact file.
+                    type: string
+                  lastUpdateTime:
+                    description: LastUpdateTime is the timestamp corresponding to
+                      the last update of the Artifact.
+                    format: date-time
+                    type: string
+                  metadata:
+                    additionalProperties:
+                      type: string
+                    description: Metadata holds upstream information such as OCI annotations.
+                    type: object
+                  path:
+                    description: Path is the relative file path of the Artifact. It
+                      can be used to locate the file in the root of the Artifact storage
+                      on the local file system of the controller managing the Source.
+                    type: string
+                  revision:
+                    description: Revision is a human-readable identifier traceable
+                      in the origin source system. It can be a Git commit SHA, Git
+                      tag, a Helm chart version, etc.
+                    type: string
+                  size:
+                    description: Size is the number of bytes in the file.
+                    format: int64
+                    type: integer
+                  url:
+                    description: URL is the HTTP address of the Artifact as exposed
+                      by the controller managing the Source. It can be used to retrieve
+                      the Artifact for consumption, e.g. by another controller applying
+                      the Artifact contents.
+                    type: string
+                required:
+                - path
+                - url
+                type: object
+              conditions:
+                description: Conditions holds the conditions for the GitRepository.
+                items:
+                  description: "Condition contains details for one aspect of the current
+                    state of this API Resource. --- This struct is intended for direct
+                    use as an array at the field path .status.conditions.  For example,
+                    \n type FooStatus struct{ // Represents the observations of a
+                    foo's current state. // Known .status.conditions.type are: \"Available\",
+                    \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge
+                    // +listType=map // +listMapKey=type Conditions []metav1.Condition
+                    `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\"
+                    protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields }"
+                  properties:
+                    lastTransitionTime:
+                      description: lastTransitionTime is the last time the condition
+                        transitioned from one status to another. This should be when
+                        the underlying condition changed.  If that is not known, then
+                        using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: message is a human readable message indicating
+                        details about the transition. This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: observedGeneration represents the .metadata.generation
+                        that the condition was set based upon. For instance, if .metadata.generation
+                        is currently 12, but the .status.conditions[x].observedGeneration
+                        is 9, the condition is out of date with respect to the current
+                        state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: reason contains a programmatic identifier indicating
+                        the reason for the condition's last transition. Producers
+                        of specific condition types may define expected values and
+                        meanings for this field, and whether the values are considered
+                        a guaranteed API. The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        --- Many .condition.type values are consistent across resources
+                        like Available, but because arbitrary conditions can be useful
+                        (see .node.status.conditions), the ability to deconflict is
+                        important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              contentConfigChecksum:
+                description: "ContentConfigChecksum is a checksum of all the configurations
+                  related to the content of the source artifact: - .spec.ignore -
+                  .spec.recurseSubmodules - .spec.included and the checksum of the
+                  included artifacts observed in .status.observedGeneration version
+                  of the object. This can be used to determine if the content of the
+                  included repository has changed. It has the format of `<algo>:<checksum>`,
+                  for example: `sha256:<checksum>`. \n Deprecated: Replaced with explicit
+                  fields for observed artifact content config in the status."
+                type: string
+              includedArtifacts:
+                description: IncludedArtifacts contains a list of the last successfully
+                  included Artifacts as instructed by GitRepositorySpec.Include.
+                items:
+                  description: Artifact represents the output of a Source reconciliation.
+                  properties:
+                    checksum:
+                      description: Checksum is the SHA256 checksum of the Artifact
+                        file.
+                      type: string
+                    lastUpdateTime:
+                      description: LastUpdateTime is the timestamp corresponding to
+                        the last update of the Artifact.
+                      format: date-time
+                      type: string
+                    metadata:
+                      additionalProperties:
+                        type: string
+                      description: Metadata holds upstream information such as OCI
+                        annotations.
+                      type: object
+                    path:
+                      description: Path is the relative file path of the Artifact.
+                        It can be used to locate the file in the root of the Artifact
+                        storage on the local file system of the controller managing
+                        the Source.
+                      type: string
+                    revision:
+                      description: Revision is a human-readable identifier traceable
+                        in the origin source system. It can be a Git commit SHA, Git
+                        tag, a Helm chart version, etc.
+                      type: string
+                    size:
+                      description: Size is the number of bytes in the file.
+                      format: int64
+                      type: integer
+                    url:
+                      description: URL is the HTTP address of the Artifact as exposed
+                        by the controller managing the Source. It can be used to retrieve
+                        the Artifact for consumption, e.g. by another controller applying
+                        the Artifact contents.
+                      type: string
+                  required:
+                  - path
+                  - url
+                  type: object
+                type: array
+              lastHandledReconcileAt:
+                description: LastHandledReconcileAt holds the value of the most recent
+                  reconcile request value, so a change of the annotation value can
+                  be detected.
+                type: string
+              observedGeneration:
+                description: ObservedGeneration is the last observed generation of
+                  the GitRepository object.
+                format: int64
+                type: integer
+              observedIgnore:
+                description: ObservedIgnore is the observed exclusion patterns used
+                  for constructing the source artifact.
+                type: string
+              observedInclude:
+                description: ObservedInclude is the observed list of GitRepository
+                  resources used to to produce the current Artifact.
+                items:
+                  description: GitRepositoryInclude specifies a local reference to
+                    a GitRepository which Artifact (sub-)contents must be included,
+                    and where they should be placed.
+                  properties:
+                    fromPath:
+                      description: FromPath specifies the path to copy contents from,
+                        defaults to the root of the Artifact.
+                      type: string
+                    repository:
+                      description: GitRepositoryRef specifies the GitRepository which
+                        Artifact contents must be included.
+                      properties:
+                        name:
+                          description: Name of the referent.
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    toPath:
+                      description: ToPath specifies the path to copy contents to,
+                        defaults to the name of the GitRepositoryRef.
+                      type: string
+                  required:
+                  - repository
+                  type: object
+                type: array
+              observedRecurseSubmodules:
+                description: ObservedRecurseSubmodules is the observed resource submodules
+                  configuration used to produce the current Artifact.
+                type: boolean
+              url:
+                description: URL is the dynamic fetch link for the latest Artifact.
+                  It is provided on a "best effort" basis, and using the precise GitRepositoryStatus.Artifact
+                  data is recommended.
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.8.0
+  creationTimestamp: null
+  name: helmcharts.source.toolkit.fluxcd.io
+spec:
+  group: source.toolkit.fluxcd.io
+  names:
+    kind: HelmChart
+    listKind: HelmChartList
+    plural: helmcharts
+    shortNames:
+    - hc
+    singular: helmchart
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .spec.chart
+      name: Chart
+      type: string
+    - jsonPath: .spec.version
+      name: Version
+      type: string
+    - jsonPath: .spec.sourceRef.kind
+      name: Source Kind
+      type: string
+    - jsonPath: .spec.sourceRef.name
+      name: Source Name
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Ready")].message
+      name: Status
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: HelmChart is the Schema for the helmcharts API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: HelmChartSpec defines the desired state of a Helm chart.
+            properties:
+              accessFrom:
+                description: AccessFrom defines an Access Control List for allowing
+                  cross-namespace references to this object.
+                properties:
+                  namespaceSelectors:
+                    description: NamespaceSelectors is the list of namespace selectors
+                      to which this ACL applies. Items in this list are evaluated
+                      using a logical OR operation.
+                    items:
+                      description: NamespaceSelector selects the namespaces to which
+                        this ACL applies. An empty map of MatchLabels matches all
+                        namespaces in a cluster.
+                      properties:
+                        matchLabels:
+                          additionalProperties:
+                            type: string
+                          description: MatchLabels is a map of {key,value} pairs.
+                            A single {key,value} in the matchLabels map is equivalent
+                            to an element of matchExpressions, whose key field is
+                            "key", the operator is "In", and the values array contains
+                            only "value". The requirements are ANDed.
+                          type: object
+                      type: object
+                    type: array
+                required:
+                - namespaceSelectors
+                type: object
+              chart:
+                description: The name or path the Helm chart is available at in the
+                  SourceRef.
+                type: string
+              interval:
+                description: The interval at which to check the Source for updates.
+                type: string
+              reconcileStrategy:
+                default: ChartVersion
+                description: Determines what enables the creation of a new artifact.
+                  Valid values are ('ChartVersion', 'Revision'). See the documentation
+                  of the values for an explanation on their behavior. Defaults to
+                  ChartVersion when omitted.
+                enum:
+                - ChartVersion
+                - Revision
+                type: string
+              sourceRef:
+                description: The reference to the Source the chart is available at.
+                properties:
+                  apiVersion:
+                    description: APIVersion of the referent.
+                    type: string
+                  kind:
+                    description: Kind of the referent, valid values are ('HelmRepository',
+                      'GitRepository', 'Bucket').
+                    enum:
+                    - HelmRepository
+                    - GitRepository
+                    - Bucket
+                    type: string
+                  name:
+                    description: Name of the referent.
+                    type: string
+                required:
+                - kind
+                - name
+                type: object
+              suspend:
+                description: This flag tells the controller to suspend the reconciliation
+                  of this source.
+                type: boolean
+              valuesFile:
+                description: Alternative values file to use as the default chart values,
+                  expected to be a relative path in the SourceRef. Deprecated in favor
+                  of ValuesFiles, for backwards compatibility the file defined here
+                  is merged before the ValuesFiles items. Ignored when omitted.
+                type: string
+              valuesFiles:
+                description: Alternative list of values files to use as the chart
+                  values (values.yaml is not included by default), expected to be
+                  a relative path in the SourceRef. Values files are merged in the
+                  order of this list with the last file overriding the first. Ignored
+                  when omitted.
+                items:
+                  type: string
+                type: array
+              version:
+                default: '*'
+                description: The chart version semver expression, ignored for charts
+                  from GitRepository and Bucket sources. Defaults to latest when omitted.
+                type: string
+            required:
+            - chart
+            - interval
+            - sourceRef
+            type: object
+          status:
+            default:
+              observedGeneration: -1
+            description: HelmChartStatus defines the observed state of the HelmChart.
+            properties:
+              artifact:
+                description: Artifact represents the output of the last successful
+                  chart sync.
+                properties:
+                  checksum:
+                    description: Checksum is the SHA256 checksum of the artifact.
+                    type: string
+                  lastUpdateTime:
+                    description: LastUpdateTime is the timestamp corresponding to
+                      the last update of this artifact.
+                    format: date-time
+                    type: string
+                  path:
+                    description: Path is the relative file path of this artifact.
+                    type: string
+                  revision:
+                    description: Revision is a human readable identifier traceable
+                      in the origin source system. It can be a Git commit SHA, Git
+                      tag, a Helm index timestamp, a Helm chart version, etc.
+                    type: string
+                  url:
+                    description: URL is the HTTP address of this artifact.
+                    type: string
+                required:
+                - path
+                - url
+                type: object
+              conditions:
+                description: Conditions holds the conditions for the HelmChart.
+                items:
+                  description: "Condition contains details for one aspect of the current
+                    state of this API Resource. --- This struct is intended for direct
+                    use as an array at the field path .status.conditions.  For example,
+                    \n type FooStatus struct{ // Represents the observations of a
+                    foo's current state. // Known .status.conditions.type are: \"Available\",
+                    \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge
+                    // +listType=map // +listMapKey=type Conditions []metav1.Condition
+                    `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\"
+                    protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields }"
+                  properties:
+                    lastTransitionTime:
+                      description: lastTransitionTime is the last time the condition
+                        transitioned from one status to another. This should be when
+                        the underlying condition changed.  If that is not known, then
+                        using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: message is a human readable message indicating
+                        details about the transition. This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: observedGeneration represents the .metadata.generation
+                        that the condition was set based upon. For instance, if .metadata.generation
+                        is currently 12, but the .status.conditions[x].observedGeneration
+                        is 9, the condition is out of date with respect to the current
+                        state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: reason contains a programmatic identifier indicating
+                        the reason for the condition's last transition. Producers
+                        of specific condition types may define expected values and
+                        meanings for this field, and whether the values are considered
+                        a guaranteed API. The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        --- Many .condition.type values are consistent across resources
+                        like Available, but because arbitrary conditions can be useful
+                        (see .node.status.conditions), the ability to deconflict is
+                        important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              lastHandledReconcileAt:
+                description: LastHandledReconcileAt holds the value of the most recent
+                  reconcile request value, so a change of the annotation value can
+                  be detected.
+                type: string
+              observedGeneration:
+                description: ObservedGeneration is the last observed generation.
+                format: int64
+                type: integer
+              url:
+                description: URL is the download link for the last chart pulled.
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
+  - additionalPrinterColumns:
+    - jsonPath: .spec.chart
+      name: Chart
+      type: string
+    - jsonPath: .spec.version
+      name: Version
+      type: string
+    - jsonPath: .spec.sourceRef.kind
+      name: Source Kind
+      type: string
+    - jsonPath: .spec.sourceRef.name
+      name: Source Name
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Ready")].message
+      name: Status
+      type: string
+    name: v1beta2
+    schema:
+      openAPIV3Schema:
+        description: HelmChart is the Schema for the helmcharts API.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: HelmChartSpec specifies the desired state of a Helm chart.
+            properties:
+              accessFrom:
+                description: 'AccessFrom specifies an Access Control List for allowing
+                  cross-namespace references to this object. NOTE: Not implemented,
+                  provisional as of https://github.com/fluxcd/flux2/pull/2092'
+                properties:
+                  namespaceSelectors:
+                    description: NamespaceSelectors is the list of namespace selectors
+                      to which this ACL applies. Items in this list are evaluated
+                      using a logical OR operation.
+                    items:
+                      description: NamespaceSelector selects the namespaces to which
+                        this ACL applies. An empty map of MatchLabels matches all
+                        namespaces in a cluster.
+                      properties:
+                        matchLabels:
+                          additionalProperties:
+                            type: string
+                          description: MatchLabels is a map of {key,value} pairs.
+                            A single {key,value} in the matchLabels map is equivalent
+                            to an element of matchExpressions, whose key field is
+                            "key", the operator is "In", and the values array contains
+                            only "value". The requirements are ANDed.
+                          type: object
+                      type: object
+                    type: array
+                required:
+                - namespaceSelectors
+                type: object
+              chart:
+                description: Chart is the name or path the Helm chart is available
+                  at in the SourceRef.
+                type: string
+              interval:
+                description: Interval is the interval at which to check the Source
+                  for updates.
+                pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
+                type: string
+              reconcileStrategy:
+                default: ChartVersion
+                description: ReconcileStrategy determines what enables the creation
+                  of a new artifact. Valid values are ('ChartVersion', 'Revision').
+                  See the documentation of the values for an explanation on their
+                  behavior. Defaults to ChartVersion when omitted.
+                enum:
+                - ChartVersion
+                - Revision
+                type: string
+              sourceRef:
+                description: SourceRef is the reference to the Source the chart is
+                  available at.
+                properties:
+                  apiVersion:
+                    description: APIVersion of the referent.
+                    type: string
+                  kind:
+                    description: Kind of the referent, valid values are ('HelmRepository',
+                      'GitRepository', 'Bucket').
+                    enum:
+                    - HelmRepository
+                    - GitRepository
+                    - Bucket
+                    type: string
+                  name:
+                    description: Name of the referent.
+                    type: string
+                required:
+                - kind
+                - name
+                type: object
+              suspend:
+                description: Suspend tells the controller to suspend the reconciliation
+                  of this source.
+                type: boolean
+              valuesFile:
+                description: ValuesFile is an alternative values file to use as the
+                  default chart values, expected to be a relative path in the SourceRef.
+                  Deprecated in favor of ValuesFiles, for backwards compatibility
+                  the file specified here is merged before the ValuesFiles items.
+                  Ignored when omitted.
+                type: string
+              valuesFiles:
+                description: ValuesFiles is an alternative list of values files to
+                  use as the chart values (values.yaml is not included by default),
+                  expected to be a relative path in the SourceRef. Values files are
+                  merged in the order of this list with the last file overriding the
+                  first. Ignored when omitted.
+                items:
+                  type: string
+                type: array
+              verify:
+                description: Verify contains the secret name containing the trusted
+                  public keys used to verify the signature and specifies which provider
+                  to use to check whether OCI image is authentic. This field is only
+                  supported when using HelmRepository source with spec.type 'oci'.
+                  Chart dependencies, which are not bundled in the umbrella chart
+                  artifact, are not verified.
+                properties:
+                  provider:
+                    default: cosign
+                    description: Provider specifies the technology used to sign the
+                      OCI Artifact.
+                    enum:
+                    - cosign
+                    type: string
+                  secretRef:
+                    description: SecretRef specifies the Kubernetes Secret containing
+                      the trusted public keys.
+                    properties:
+                      name:
+                        description: Name of the referent.
+                        type: string
+                    required:
+                    - name
+                    type: object
+                required:
+                - provider
+                type: object
+              version:
+                default: '*'
+                description: Version is the chart version semver expression, ignored
+                  for charts from GitRepository and Bucket sources. Defaults to latest
+                  when omitted.
+                type: string
+            required:
+            - chart
+            - interval
+            - sourceRef
+            type: object
+          status:
+            default:
+              observedGeneration: -1
+            description: HelmChartStatus records the observed state of the HelmChart.
+            properties:
+              artifact:
+                description: Artifact represents the output of the last successful
+                  reconciliation.
+                properties:
+                  checksum:
+                    description: Checksum is the SHA256 checksum of the Artifact file.
+                    type: string
+                  lastUpdateTime:
+                    description: LastUpdateTime is the timestamp corresponding to
+                      the last update of the Artifact.
+                    format: date-time
+                    type: string
+                  metadata:
+                    additionalProperties:
+                      type: string
+                    description: Metadata holds upstream information such as OCI annotations.
+                    type: object
+                  path:
+                    description: Path is the relative file path of the Artifact. It
+                      can be used to locate the file in the root of the Artifact storage
+                      on the local file system of the controller managing the Source.
+                    type: string
+                  revision:
+                    description: Revision is a human-readable identifier traceable
+                      in the origin source system. It can be a Git commit SHA, Git
+                      tag, a Helm chart version, etc.
+                    type: string
+                  size:
+                    description: Size is the number of bytes in the file.
+                    format: int64
+                    type: integer
+                  url:
+                    description: URL is the HTTP address of the Artifact as exposed
+                      by the controller managing the Source. It can be used to retrieve
+                      the Artifact for consumption, e.g. by another controller applying
+                      the Artifact contents.
+                    type: string
+                required:
+                - path
+                - url
+                type: object
+              conditions:
+                description: Conditions holds the conditions for the HelmChart.
+                items:
+                  description: "Condition contains details for one aspect of the current
+                    state of this API Resource. --- This struct is intended for direct
+                    use as an array at the field path .status.conditions.  For example,
+                    \n type FooStatus struct{ // Represents the observations of a
+                    foo's current state. // Known .status.conditions.type are: \"Available\",
+                    \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge
+                    // +listType=map // +listMapKey=type Conditions []metav1.Condition
+                    `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\"
+                    protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields }"
+                  properties:
+                    lastTransitionTime:
+                      description: lastTransitionTime is the last time the condition
+                        transitioned from one status to another. This should be when
+                        the underlying condition changed.  If that is not known, then
+                        using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: message is a human readable message indicating
+                        details about the transition. This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: observedGeneration represents the .metadata.generation
+                        that the condition was set based upon. For instance, if .metadata.generation
+                        is currently 12, but the .status.conditions[x].observedGeneration
+                        is 9, the condition is out of date with respect to the current
+                        state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: reason contains a programmatic identifier indicating
+                        the reason for the condition's last transition. Producers
+                        of specific condition types may define expected values and
+                        meanings for this field, and whether the values are considered
+                        a guaranteed API. The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        --- Many .condition.type values are consistent across resources
+                        like Available, but because arbitrary conditions can be useful
+                        (see .node.status.conditions), the ability to deconflict is
+                        important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              lastHandledReconcileAt:
+                description: LastHandledReconcileAt holds the value of the most recent
+                  reconcile request value, so a change of the annotation value can
+                  be detected.
+                type: string
+              observedChartName:
+                description: ObservedChartName is the last observed chart name as
+                  specified by the resolved chart reference.
+                type: string
+              observedGeneration:
+                description: ObservedGeneration is the last observed generation of
+                  the HelmChart object.
+                format: int64
+                type: integer
+              observedSourceArtifactRevision:
+                description: ObservedSourceArtifactRevision is the last observed Artifact.Revision
+                  of the HelmChartSpec.SourceRef.
+                type: string
+              url:
+                description: URL is the dynamic fetch link for the latest Artifact.
+                  It is provided on a "best effort" basis, and using the precise BucketStatus.Artifact
+                  data is recommended.
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.11.1
+  creationTimestamp: null
+  name: helmreleases.helm.toolkit.fluxcd.io
+spec:
+  group: helm.toolkit.fluxcd.io
+  names:
+    kind: HelmRelease
+    listKind: HelmReleaseList
+    plural: helmreleases
+    shortNames:
+    - hr
+    singular: helmrelease
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Ready")].message
+      name: Status
+      type: string
+    name: v2beta1
+    schema:
+      openAPIV3Schema:
+        description: HelmRelease is the Schema for the helmreleases API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: HelmReleaseSpec defines the desired state of a Helm release.
+            properties:
+              chart:
+                description: Chart defines the template of the v1beta2.HelmChart that
+                  should be created for this HelmRelease.
+                properties:
+                  spec:
+                    description: Spec holds the template for the v1beta2.HelmChartSpec
+                      for this HelmRelease.
+                    properties:
+                      chart:
+                        description: The name or path the Helm chart is available
+                          at in the SourceRef.
+                        type: string
+                      interval:
+                        description: Interval at which to check the v1beta2.Source
+                          for updates. Defaults to 'HelmReleaseSpec.Interval'.
+                        pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
+                        type: string
+                      reconcileStrategy:
+                        default: ChartVersion
+                        description: Determines what enables the creation of a new
+                          artifact. Valid values are ('ChartVersion', 'Revision').
+                          See the documentation of the values for an explanation on
+                          their behavior. Defaults to ChartVersion when omitted.
+                        enum:
+                        - ChartVersion
+                        - Revision
+                        type: string
+                      sourceRef:
+                        description: The name and namespace of the v1beta2.Source
+                          the chart is available at.
+                        properties:
+                          apiVersion:
+                            description: APIVersion of the referent.
+                            type: string
+                          kind:
+                            description: Kind of the referent.
+                            enum:
+                            - HelmRepository
+                            - GitRepository
+                            - Bucket
+                            type: string
+                          name:
+                            description: Name of the referent.
+                            maxLength: 253
+                            minLength: 1
+                            type: string
+                          namespace:
+                            description: Namespace of the referent.
+                            maxLength: 63
+                            minLength: 1
+                            type: string
+                        required:
+                        - name
+                        type: object
+                      valuesFile:
+                        description: Alternative values file to use as the default
+                          chart values, expected to be a relative path in the SourceRef.
+                          Deprecated in favor of ValuesFiles, for backwards compatibility
+                          the file defined here is merged before the ValuesFiles items.
+                          Ignored when omitted.
+                        type: string
+                      valuesFiles:
+                        description: Alternative list of values files to use as the
+                          chart values (values.yaml is not included by default), expected
+                          to be a relative path in the SourceRef. Values files are
+                          merged in the order of this list with the last file overriding
+                          the first. Ignored when omitted.
+                        items:
+                          type: string
+                        type: array
+                      verify:
+                        description: Verify contains the secret name containing the
+                          trusted public keys used to verify the signature and specifies
+                          which provider to use to check whether OCI image is authentic.
+                          This field is only supported for OCI sources. Chart dependencies,
+                          which are not bundled in the umbrella chart artifact, are
+                          not verified.
+                        properties:
+                          provider:
+                            default: cosign
+                            description: Provider specifies the technology used to
+                              sign the OCI Helm chart.
+                            enum:
+                            - cosign
+                            type: string
+                          secretRef:
+                            description: SecretRef specifies the Kubernetes Secret
+                              containing the trusted public keys.
+                            properties:
+                              name:
+                                description: Name of the referent.
+                                type: string
+                            required:
+                            - name
+                            type: object
+                        required:
+                        - provider
+                        type: object
+                      version:
+                        default: '*'
+                        description: Version semver expression, ignored for charts
+                          from v1beta2.GitRepository and v1beta2.Bucket sources. Defaults
+                          to latest when omitted.
+                        type: string
+                    required:
+                    - chart
+                    - sourceRef
+                    type: object
+                required:
+                - spec
+                type: object
+              dependsOn:
+                description: DependsOn may contain a meta.NamespacedObjectReference
+                  slice with references to HelmRelease resources that must be ready
+                  before this HelmRelease can be reconciled.
+                items:
+                  description: NamespacedObjectReference contains enough information
+                    to locate the referenced Kubernetes resource object in any namespace.
+                  properties:
+                    name:
+                      description: Name of the referent.
+                      type: string
+                    namespace:
+                      description: Namespace of the referent, when not specified it
+                        acts as LocalObjectReference.
+                      type: string
+                  required:
+                  - name
+                  type: object
+                type: array
+              install:
+                description: Install holds the configuration for Helm install actions
+                  for this HelmRelease.
+                properties:
+                  crds:
+                    description: "CRDs upgrade CRDs from the Helm Chart's crds directory
+                      according to the CRD upgrade policy provided here. Valid values
+                      are `Skip`, `Create` or `CreateReplace`. Default is `Create`
+                      and if omitted CRDs are installed but not updated. \n Skip:
+                      do neither install nor replace (update) any CRDs. \n Create:
+                      new CRDs are created, existing CRDs are neither updated nor
+                      deleted. \n CreateReplace: new CRDs are created, existing CRDs
+                      are updated (replaced) but not deleted. \n By default, CRDs
+                      are applied (installed) during Helm install action. With this
+                      option users can opt-in to CRD replace existing CRDs on Helm
+                      install actions, which is not (yet) natively supported by Helm.
+                      https://helm.sh/docs/chart_best_practices/custom_resource_definitions."
+                    enum:
+                    - Skip
+                    - Create
+                    - CreateReplace
+                    type: string
+                  createNamespace:
+                    description: CreateNamespace tells the Helm install action to
+                      create the HelmReleaseSpec.TargetNamespace if it does not exist
+                      yet. On uninstall, the namespace will not be garbage collected.
+                    type: boolean
+                  disableHooks:
+                    description: DisableHooks prevents hooks from running during the
+                      Helm install action.
+                    type: boolean
+                  disableOpenAPIValidation:
+                    description: DisableOpenAPIValidation prevents the Helm install
+                      action from validating rendered templates against the Kubernetes
+                      OpenAPI Schema.
+                    type: boolean
+                  disableWait:
+                    description: DisableWait disables the waiting for resources to
+                      be ready after a Helm install has been performed.
+                    type: boolean
+                  disableWaitForJobs:
+                    description: DisableWaitForJobs disables waiting for jobs to complete
+                      after a Helm install has been performed.
+                    type: boolean
+                  remediation:
+                    description: Remediation holds the remediation configuration for
+                      when the Helm install action for the HelmRelease fails. The
+                      default is to not perform any action.
+                    properties:
+                      ignoreTestFailures:
+                        description: IgnoreTestFailures tells the controller to skip
+                          remediation when the Helm tests are run after an install
+                          action but fail. Defaults to 'Test.IgnoreFailures'.
+                        type: boolean
+                      remediateLastFailure:
+                        description: RemediateLastFailure tells the controller to
+                          remediate the last failure, when no retries remain. Defaults
+                          to 'false'.
+                        type: boolean
+                      retries:
+                        description: Retries is the number of retries that should
+                          be attempted on failures before bailing. Remediation, using
+                          an uninstall, is performed between each attempt. Defaults
+                          to '0', a negative integer equals to unlimited retries.
+                        type: integer
+                    type: object
+                  replace:
+                    description: Replace tells the Helm install action to re-use the
+                      'ReleaseName', but only if that name is a deleted release which
+                      remains in the history.
+                    type: boolean
+                  skipCRDs:
+                    description: "SkipCRDs tells the Helm install action to not install
+                      any CRDs. By default, CRDs are installed if not already present.
+                      \n Deprecated use CRD policy (`crds`) attribute with value `Skip`
+                      instead."
+                    type: boolean
+                  timeout:
+                    description: Timeout is the time to wait for any individual Kubernetes
+                      operation (like Jobs for hooks) during the performance of a
+                      Helm install action. Defaults to 'HelmReleaseSpec.Timeout'.
+                    pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
+                    type: string
+                type: object
+              interval:
+                description: Interval at which to reconcile the Helm release.
+                pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
+                type: string
+              kubeConfig:
+                description: KubeConfig for reconciling the HelmRelease on a remote
+                  cluster. When used in combination with HelmReleaseSpec.ServiceAccountName,
+                  forces the controller to act on behalf of that Service Account at
+                  the target cluster. If the --default-service-account flag is set,
+                  its value will be used as a controller level fallback for when HelmReleaseSpec.ServiceAccountName
+                  is empty.
+                properties:
+                  secretRef:
+                    description: SecretRef holds the name to a secret that contains
+                      a key with the kubeconfig file as the value. If no key is specified
+                      the key will default to 'value'. The secret must be in the same
+                      namespace as the HelmRelease. It is recommended that the kubeconfig
+                      is self-contained, and the secret is regularly updated if credentials
+                      such as a cloud-access-token expire. Cloud specific `cmd-path`
+                      auth helpers will not function without adding binaries and credentials
+                      to the Pod that is responsible for reconciling the HelmRelease.
+                    properties:
+                      key:
+                        description: Key in the Secret, when not specified an implementation-specific
+                          default key is used.
+                        type: string
+                      name:
+                        description: Name of the Secret.
+                        type: string
+                    required:
+                    - name
+                    type: object
+                type: object
+              maxHistory:
+                description: MaxHistory is the number of revisions saved by Helm for
+                  this HelmRelease. Use '0' for an unlimited number of revisions;
+                  defaults to '10'.
+                type: integer
+              postRenderers:
+                description: PostRenderers holds an array of Helm PostRenderers, which
+                  will be applied in order of their definition.
+                items:
+                  description: PostRenderer contains a Helm PostRenderer specification.
+                  properties:
+                    kustomize:
+                      description: Kustomization to apply as PostRenderer.
+                      properties:
+                        images:
+                          description: Images is a list of (image name, new name,
+                            new tag or digest) for changing image names, tags or digests.
+                            This can also be achieved with a patch, but this operator
+                            is simpler to specify.
+                          items:
+                            description: Image contains an image name, a new name,
+                              a new tag or digest, which will replace the original
+                              name and tag.
+                            properties:
+                              digest:
+                                description: Digest is the value used to replace the
+                                  original image tag. If digest is present NewTag
+                                  value is ignored.
+                                type: string
+                              name:
+                                description: Name is a tag-less image name.
+                                type: string
+                              newName:
+                                description: NewName is the value used to replace
+                                  the original name.
+                                type: string
+                              newTag:
+                                description: NewTag is the value used to replace the
+                                  original tag.
+                                type: string
+                            required:
+                            - name
+                            type: object
+                          type: array
+                        patches:
+                          description: Strategic merge and JSON patches, defined as
+                            inline YAML objects, capable of targeting objects based
+                            on kind, label and annotation selectors.
+                          items:
+                            description: Patch contains an inline StrategicMerge or
+                              JSON6902 patch, and the target the patch should be applied
+                              to.
+                            properties:
+                              patch:
+                                description: Patch contains an inline StrategicMerge
+                                  patch or an inline JSON6902 patch with an array
+                                  of operation objects.
+                                type: string
+                              target:
+                                description: Target points to the resources that the
+                                  patch document should be applied to.
+                                properties:
+                                  annotationSelector:
+                                    description: AnnotationSelector is a string that
+                                      follows the label selection expression https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#api
+                                      It matches with the resource annotations.
+                                    type: string
+                                  group:
+                                    description: Group is the API group to select
+                                      resources from. Together with Version and Kind
+                                      it is capable of unambiguously identifying and/or
+                                      selecting resources. https://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/api-group.md
+                                    type: string
+                                  kind:
+                                    description: Kind of the API Group to select resources
+                                      from. Together with Group and Version it is
+                                      capable of unambiguously identifying and/or
+                                      selecting resources. https://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/api-group.md
+                                    type: string
+                                  labelSelector:
+                                    description: LabelSelector is a string that follows
+                                      the label selection expression https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#api
+                                      It matches with the resource labels.
+                                    type: string
+                                  name:
+                                    description: Name to match resources with.
+                                    type: string
+                                  namespace:
+                                    description: Namespace to select resources from.
+                                    type: string
+                                  version:
+                                    description: Version of the API Group to select
+                                      resources from. Together with Group and Kind
+                                      it is capable of unambiguously identifying and/or
+                                      selecting resources. https://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/api-group.md
+                                    type: string
+                                type: object
+                            type: object
+                          type: array
+                        patchesJson6902:
+                          description: JSON 6902 patches, defined as inline YAML objects.
+                          items:
+                            description: JSON6902Patch contains a JSON6902 patch and
+                              the target the patch should be applied to.
+                            properties:
+                              patch:
+                                description: Patch contains the JSON6902 patch document
+                                  with an array of operation objects.
+                                items:
+                                  description: JSON6902 is a JSON6902 operation object.
+                                    https://datatracker.ietf.org/doc/html/rfc6902#section-4
+                                  properties:
+                                    from:
+                                      description: From contains a JSON-pointer value
+                                        that references a location within the target
+                                        document where the operation is performed.
+                                        The meaning of the value depends on the value
+                                        of Op, and is NOT taken into account by all
+                                        operations.
+                                      type: string
+                                    op:
+                                      description: Op indicates the operation to perform.
+                                        Its value MUST be one of "add", "remove",
+                                        "replace", "move", "copy", or "test". https://datatracker.ietf.org/doc/html/rfc6902#section-4
+                                      enum:
+                                      - test
+                                      - remove
+                                      - add
+                                      - replace
+                                      - move
+                                      - copy
+                                      type: string
+                                    path:
+                                      description: Path contains the JSON-pointer
+                                        value that references a location within the
+                                        target document where the operation is performed.
+                                        The meaning of the value depends on the value
+                                        of Op.
+                                      type: string
+                                    value:
+                                      description: Value contains a valid JSON structure.
+                                        The meaning of the value depends on the value
+                                        of Op, and is NOT taken into account by all
+                                        operations.
+                                      x-kubernetes-preserve-unknown-fields: true
+                                  required:
+                                  - op
+                                  - path
+                                  type: object
+                                type: array
+                              target:
+                                description: Target points to the resources that the
+                                  patch document should be applied to.
+                                properties:
+                                  annotationSelector:
+                                    description: AnnotationSelector is a string that
+                                      follows the label selection expression https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#api
+                                      It matches with the resource annotations.
+                                    type: string
+                                  group:
+                                    description: Group is the API group to select
+                                      resources from. Together with Version and Kind
+                                      it is capable of unambiguously identifying and/or
+                                      selecting resources. https://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/api-group.md
+                                    type: string
+                                  kind:
+                                    description: Kind of the API Group to select resources
+                                      from. Together with Group and Version it is
+                                      capable of unambiguously identifying and/or
+                                      selecting resources. https://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/api-group.md
+                                    type: string
+                                  labelSelector:
+                                    description: LabelSelector is a string that follows
+                                      the label selection expression https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#api
+                                      It matches with the resource labels.
+                                    type: string
+                                  name:
+                                    description: Name to match resources with.
+                                    type: string
+                                  namespace:
+                                    description: Namespace to select resources from.
+                                    type: string
+                                  version:
+                                    description: Version of the API Group to select
+                                      resources from. Together with Group and Kind
+                                      it is capable of unambiguously identifying and/or
+                                      selecting resources. https://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/api-group.md
+                                    type: string
+                                type: object
+                            required:
+                            - patch
+                            - target
+                            type: object
+                          type: array
+                        patchesStrategicMerge:
+                          description: Strategic merge patches, defined as inline
+                            YAML objects.
+                          items:
+                            x-kubernetes-preserve-unknown-fields: true
+                          type: array
+                      type: object
+                  type: object
+                type: array
+              releaseName:
+                description: ReleaseName used for the Helm release. Defaults to a
+                  composition of '[TargetNamespace-]Name'.
+                maxLength: 53
+                minLength: 1
+                type: string
+              rollback:
+                description: Rollback holds the configuration for Helm rollback actions
+                  for this HelmRelease.
+                properties:
+                  cleanupOnFail:
+                    description: CleanupOnFail allows deletion of new resources created
+                      during the Helm rollback action when it fails.
+                    type: boolean
+                  disableHooks:
+                    description: DisableHooks prevents hooks from running during the
+                      Helm rollback action.
+                    type: boolean
+                  disableWait:
+                    description: DisableWait disables the waiting for resources to
+                      be ready after a Helm rollback has been performed.
+                    type: boolean
+                  disableWaitForJobs:
+                    description: DisableWaitForJobs disables waiting for jobs to complete
+                      after a Helm rollback has been performed.
+                    type: boolean
+                  force:
+                    description: Force forces resource updates through a replacement
+                      strategy.
+                    type: boolean
+                  recreate:
+                    description: Recreate performs pod restarts for the resource if
+                      applicable.
+                    type: boolean
+                  timeout:
+                    description: Timeout is the time to wait for any individual Kubernetes
+                      operation (like Jobs for hooks) during the performance of a
+                      Helm rollback action. Defaults to 'HelmReleaseSpec.Timeout'.
+                    pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
+                    type: string
+                type: object
+              serviceAccountName:
+                description: The name of the Kubernetes service account to impersonate
+                  when reconciling this HelmRelease.
+                type: string
+              storageNamespace:
+                description: StorageNamespace used for the Helm storage. Defaults
+                  to the namespace of the HelmRelease.
+                maxLength: 63
+                minLength: 1
+                type: string
+              suspend:
+                description: Suspend tells the controller to suspend reconciliation
+                  for this HelmRelease, it does not apply to already started reconciliations.
+                  Defaults to false.
+                type: boolean
+              targetNamespace:
+                description: TargetNamespace to target when performing operations
+                  for the HelmRelease. Defaults to the namespace of the HelmRelease.
+                maxLength: 63
+                minLength: 1
+                type: string
+              test:
+                description: Test holds the configuration for Helm test actions for
+                  this HelmRelease.
+                properties:
+                  enable:
+                    description: Enable enables Helm test actions for this HelmRelease
+                      after an Helm install or upgrade action has been performed.
+                    type: boolean
+                  ignoreFailures:
+                    description: IgnoreFailures tells the controller to skip remediation
+                      when the Helm tests are run but fail. Can be overwritten for
+                      tests run after install or upgrade actions in 'Install.IgnoreTestFailures'
+                      and 'Upgrade.IgnoreTestFailures'.
+                    type: boolean
+                  timeout:
+                    description: Timeout is the time to wait for any individual Kubernetes
+                      operation during the performance of a Helm test action. Defaults
+                      to 'HelmReleaseSpec.Timeout'.
+                    pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
+                    type: string
+                type: object
+              timeout:
+                description: Timeout is the time to wait for any individual Kubernetes
+                  operation (like Jobs for hooks) during the performance of a Helm
+                  action. Defaults to '5m0s'.
+                pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
+                type: string
+              uninstall:
+                description: Uninstall holds the configuration for Helm uninstall
+                  actions for this HelmRelease.
+                properties:
+                  disableHooks:
+                    description: DisableHooks prevents hooks from running during the
+                      Helm rollback action.
+                    type: boolean
+                  disableWait:
+                    description: DisableWait disables waiting for all the resources
+                      to be deleted after a Helm uninstall is performed.
+                    type: boolean
+                  keepHistory:
+                    description: KeepHistory tells Helm to remove all associated resources
+                      and mark the release as deleted, but retain the release history.
+                    type: boolean
+                  timeout:
+                    description: Timeout is the time to wait for any individual Kubernetes
+                      operation (like Jobs for hooks) during the performance of a
+                      Helm uninstall action. Defaults to 'HelmReleaseSpec.Timeout'.
+                    pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
+                    type: string
+                type: object
+              upgrade:
+                description: Upgrade holds the configuration for Helm upgrade actions
+                  for this HelmRelease.
+                properties:
+                  cleanupOnFail:
+                    description: CleanupOnFail allows deletion of new resources created
+                      during the Helm upgrade action when it fails.
+                    type: boolean
+                  crds:
+                    description: "CRDs upgrade CRDs from the Helm Chart's crds directory
+                      according to the CRD upgrade policy provided here. Valid values
+                      are `Skip`, `Create` or `CreateReplace`. Default is `Skip` and
+                      if omitted CRDs are neither installed nor upgraded. \n Skip:
+                      do neither install nor replace (update) any CRDs. \n Create:
+                      new CRDs are created, existing CRDs are neither updated nor
+                      deleted. \n CreateReplace: new CRDs are created, existing CRDs
+                      are updated (replaced) but not deleted. \n By default, CRDs
+                      are not applied during Helm upgrade action. With this option
+                      users can opt-in to CRD upgrade, which is not (yet) natively
+                      supported by Helm. https://helm.sh/docs/chart_best_practices/custom_resource_definitions."
+                    enum:
+                    - Skip
+                    - Create
+                    - CreateReplace
+                    type: string
+                  disableHooks:
+                    description: DisableHooks prevents hooks from running during the
+                      Helm upgrade action.
+                    type: boolean
+                  disableOpenAPIValidation:
+                    description: DisableOpenAPIValidation prevents the Helm upgrade
+                      action from validating rendered templates against the Kubernetes
+                      OpenAPI Schema.
+                    type: boolean
+                  disableWait:
+                    description: DisableWait disables the waiting for resources to
+                      be ready after a Helm upgrade has been performed.
+                    type: boolean
+                  disableWaitForJobs:
+                    description: DisableWaitForJobs disables waiting for jobs to complete
+                      after a Helm upgrade has been performed.
+                    type: boolean
+                  force:
+                    description: Force forces resource updates through a replacement
+                      strategy.
+                    type: boolean
+                  preserveValues:
+                    description: PreserveValues will make Helm reuse the last release's
+                      values and merge in overrides from 'Values'. Setting this flag
+                      makes the HelmRelease non-declarative.
+                    type: boolean
+                  remediation:
+                    description: Remediation holds the remediation configuration for
+                      when the Helm upgrade action for the HelmRelease fails. The
+                      default is to not perform any action.
+                    properties:
+                      ignoreTestFailures:
+                        description: IgnoreTestFailures tells the controller to skip
+                          remediation when the Helm tests are run after an upgrade
+                          action but fail. Defaults to 'Test.IgnoreFailures'.
+                        type: boolean
+                      remediateLastFailure:
+                        description: RemediateLastFailure tells the controller to
+                          remediate the last failure, when no retries remain. Defaults
+                          to 'false' unless 'Retries' is greater than 0.
+                        type: boolean
+                      retries:
+                        description: Retries is the number of retries that should
+                          be attempted on failures before bailing. Remediation, using
+                          'Strategy', is performed between each attempt. Defaults
+                          to '0', a negative integer equals to unlimited retries.
+                        type: integer
+                      strategy:
+                        description: Strategy to use for failure remediation. Defaults
+                          to 'rollback'.
+                        enum:
+                        - rollback
+                        - uninstall
+                        type: string
+                    type: object
+                  timeout:
+                    description: Timeout is the time to wait for any individual Kubernetes
+                      operation (like Jobs for hooks) during the performance of a
+                      Helm upgrade action. Defaults to 'HelmReleaseSpec.Timeout'.
+                    pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
+                    type: string
+                type: object
+              values:
+                description: Values holds the values for this Helm release.
+                x-kubernetes-preserve-unknown-fields: true
+              valuesFrom:
+                description: ValuesFrom holds references to resources containing Helm
+                  values for this HelmRelease, and information about how they should
+                  be merged.
+                items:
+                  description: ValuesReference contains a reference to a resource
+                    containing Helm values, and optionally the key they can be found
+                    at.
+                  properties:
+                    kind:
+                      description: Kind of the values referent, valid values are ('Secret',
+                        'ConfigMap').
+                      enum:
+                      - Secret
+                      - ConfigMap
+                      type: string
+                    name:
+                      description: Name of the values referent. Should reside in the
+                        same namespace as the referring resource.
+                      maxLength: 253
+                      minLength: 1
+                      type: string
+                    optional:
+                      description: Optional marks this ValuesReference as optional.
+                        When set, a not found error for the values reference is ignored,
+                        but any ValuesKey, TargetPath or transient error will still
+                        result in a reconciliation failure.
+                      type: boolean
+                    targetPath:
+                      description: TargetPath is the YAML dot notation path the value
+                        should be merged at. When set, the ValuesKey is expected to
+                        be a single flat value. Defaults to 'None', which results
+                        in the values getting merged at the root.
+                      maxLength: 250
+                      pattern: ^([a-zA-Z0-9_\-.\\\/]|\[[0-9]{1,5}\])+$
+                      type: string
+                    valuesKey:
+                      description: ValuesKey is the data key where the values.yaml
+                        or a specific value can be found at. Defaults to 'values.yaml'.
+                        When set, must be a valid Data Key, consisting of alphanumeric
+                        characters, '-', '_' or '.'.
+                      maxLength: 253
+                      pattern: ^[\-._a-zA-Z0-9]+$
+                      type: string
+                  required:
+                  - kind
+                  - name
+                  type: object
+                type: array
+            required:
+            - chart
+            - interval
+            type: object
+          status:
+            default:
+              observedGeneration: -1
+            description: HelmReleaseStatus defines the observed state of a HelmRelease.
+            properties:
+              conditions:
+                description: Conditions holds the conditions for the HelmRelease.
+                items:
+                  description: "Condition contains details for one aspect of the current
+                    state of this API Resource. --- This struct is intended for direct
+                    use as an array at the field path .status.conditions.  For example,
+                    \n type FooStatus struct{ // Represents the observations of a
+                    foo's current state. // Known .status.conditions.type are: \"Available\",
+                    \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge
+                    // +listType=map // +listMapKey=type Conditions []metav1.Condition
+                    `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\"
+                    protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields }"
+                  properties:
+                    lastTransitionTime:
+                      description: lastTransitionTime is the last time the condition
+                        transitioned from one status to another. This should be when
+                        the underlying condition changed.  If that is not known, then
+                        using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: message is a human readable message indicating
+                        details about the transition. This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: observedGeneration represents the .metadata.generation
+                        that the condition was set based upon. For instance, if .metadata.generation
+                        is currently 12, but the .status.conditions[x].observedGeneration
+                        is 9, the condition is out of date with respect to the current
+                        state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: reason contains a programmatic identifier indicating
+                        the reason for the condition's last transition. Producers
+                        of specific condition types may define expected values and
+                        meanings for this field, and whether the values are considered
+                        a guaranteed API. The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        --- Many .condition.type values are consistent across resources
+                        like Available, but because arbitrary conditions can be useful
+                        (see .node.status.conditions), the ability to deconflict is
+                        important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              failures:
+                description: Failures is the reconciliation failure count against
+                  the latest desired state. It is reset after a successful reconciliation.
+                format: int64
+                type: integer
+              helmChart:
+                description: HelmChart is the namespaced name of the HelmChart resource
+                  created by the controller for the HelmRelease.
+                type: string
+              installFailures:
+                description: InstallFailures is the install failure count against
+                  the latest desired state. It is reset after a successful reconciliation.
+                format: int64
+                type: integer
+              lastAppliedRevision:
+                description: LastAppliedRevision is the revision of the last successfully
+                  applied source.
+                type: string
+              lastAttemptedRevision:
+                description: LastAttemptedRevision is the revision of the last reconciliation
+                  attempt.
+                type: string
+              lastAttemptedValuesChecksum:
+                description: LastAttemptedValuesChecksum is the SHA1 checksum of the
+                  values of the last reconciliation attempt.
+                type: string
+              lastHandledReconcileAt:
+                description: LastHandledReconcileAt holds the value of the most recent
+                  reconcile request value, so a change of the annotation value can
+                  be detected.
+                type: string
+              lastReleaseRevision:
+                description: LastReleaseRevision is the revision of the last successful
+                  Helm release.
+                type: integer
+              observedGeneration:
+                description: ObservedGeneration is the last observed generation.
+                format: int64
+                type: integer
+              upgradeFailures:
+                description: UpgradeFailures is the upgrade failure count against
+                  the latest desired state. It is reset after a successful reconciliation.
+                format: int64
+                type: integer
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.8.0
+  creationTimestamp: null
+  name: helmrepositories.source.toolkit.fluxcd.io
+spec:
+  group: source.toolkit.fluxcd.io
+  names:
+    kind: HelmRepository
+    listKind: HelmRepositoryList
+    plural: helmrepositories
+    shortNames:
+    - helmrepo
+    singular: helmrepository
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .spec.url
+      name: URL
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Ready")].message
+      name: Status
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: HelmRepository is the Schema for the helmrepositories API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: HelmRepositorySpec defines the reference to a Helm repository.
+            properties:
+              accessFrom:
+                description: AccessFrom defines an Access Control List for allowing
+                  cross-namespace references to this object.
+                properties:
+                  namespaceSelectors:
+                    description: NamespaceSelectors is the list of namespace selectors
+                      to which this ACL applies. Items in this list are evaluated
+                      using a logical OR operation.
+                    items:
+                      description: NamespaceSelector selects the namespaces to which
+                        this ACL applies. An empty map of MatchLabels matches all
+                        namespaces in a cluster.
+                      properties:
+                        matchLabels:
+                          additionalProperties:
+                            type: string
+                          description: MatchLabels is a map of {key,value} pairs.
+                            A single {key,value} in the matchLabels map is equivalent
+                            to an element of matchExpressions, whose key field is
+                            "key", the operator is "In", and the values array contains
+                            only "value". The requirements are ANDed.
+                          type: object
+                      type: object
+                    type: array
+                required:
+                - namespaceSelectors
+                type: object
+              interval:
+                description: The interval at which to check the upstream for updates.
+                type: string
+              passCredentials:
+                description: PassCredentials allows the credentials from the SecretRef
+                  to be passed on to a host that does not match the host as defined
+                  in URL. This may be required if the host of the advertised chart
+                  URLs in the index differ from the defined URL. Enabling this should
+                  be done with caution, as it can potentially result in credentials
+                  getting stolen in a MITM-attack.
+                type: boolean
+              secretRef:
+                description: The name of the secret containing authentication credentials
+                  for the Helm repository. For HTTP/S basic auth the secret must contain
+                  username and password fields. For TLS the secret must contain a
+                  certFile and keyFile, and/or caCert fields.
+                properties:
+                  name:
+                    description: Name of the referent.
+                    type: string
+                required:
+                - name
+                type: object
+              suspend:
+                description: This flag tells the controller to suspend the reconciliation
+                  of this source.
+                type: boolean
+              timeout:
+                default: 60s
+                description: The timeout of index downloading, defaults to 60s.
+                type: string
+              url:
+                description: The Helm repository URL, a valid URL contains at least
+                  a protocol and host.
+                type: string
+            required:
+            - interval
+            - url
+            type: object
+          status:
+            default:
+              observedGeneration: -1
+            description: HelmRepositoryStatus defines the observed state of the HelmRepository.
+            properties:
+              artifact:
+                description: Artifact represents the output of the last successful
+                  repository sync.
+                properties:
+                  checksum:
+                    description: Checksum is the SHA256 checksum of the artifact.
+                    type: string
+                  lastUpdateTime:
+                    description: LastUpdateTime is the timestamp corresponding to
+                      the last update of this artifact.
+                    format: date-time
+                    type: string
+                  path:
+                    description: Path is the relative file path of this artifact.
+                    type: string
+                  revision:
+                    description: Revision is a human readable identifier traceable
+                      in the origin source system. It can be a Git commit SHA, Git
+                      tag, a Helm index timestamp, a Helm chart version, etc.
+                    type: string
+                  url:
+                    description: URL is the HTTP address of this artifact.
+                    type: string
+                required:
+                - path
+                - url
+                type: object
+              conditions:
+                description: Conditions holds the conditions for the HelmRepository.
+                items:
+                  description: "Condition contains details for one aspect of the current
+                    state of this API Resource. --- This struct is intended for direct
+                    use as an array at the field path .status.conditions.  For example,
+                    \n type FooStatus struct{ // Represents the observations of a
+                    foo's current state. // Known .status.conditions.type are: \"Available\",
+                    \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge
+                    // +listType=map // +listMapKey=type Conditions []metav1.Condition
+                    `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\"
+                    protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields }"
+                  properties:
+                    lastTransitionTime:
+                      description: lastTransitionTime is the last time the condition
+                        transitioned from one status to another. This should be when
+                        the underlying condition changed.  If that is not known, then
+                        using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: message is a human readable message indicating
+                        details about the transition. This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: observedGeneration represents the .metadata.generation
+                        that the condition was set based upon. For instance, if .metadata.generation
+                        is currently 12, but the .status.conditions[x].observedGeneration
+                        is 9, the condition is out of date with respect to the current
+                        state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: reason contains a programmatic identifier indicating
+                        the reason for the condition's last transition. Producers
+                        of specific condition types may define expected values and
+                        meanings for this field, and whether the values are considered
+                        a guaranteed API. The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        --- Many .condition.type values are consistent across resources
+                        like Available, but because arbitrary conditions can be useful
+                        (see .node.status.conditions), the ability to deconflict is
+                        important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              lastHandledReconcileAt:
+                description: LastHandledReconcileAt holds the value of the most recent
+                  reconcile request value, so a change of the annotation value can
+                  be detected.
+                type: string
+              observedGeneration:
+                description: ObservedGeneration is the last observed generation.
+                format: int64
+                type: integer
+              url:
+                description: URL is the download link for the last index fetched.
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
+  - additionalPrinterColumns:
+    - jsonPath: .spec.url
+      name: URL
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Ready")].message
+      name: Status
+      type: string
+    name: v1beta2
+    schema:
+      openAPIV3Schema:
+        description: HelmRepository is the Schema for the helmrepositories API.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: HelmRepositorySpec specifies the required configuration to
+              produce an Artifact for a Helm repository index YAML.
+            properties:
+              accessFrom:
+                description: 'AccessFrom specifies an Access Control List for allowing
+                  cross-namespace references to this object. NOTE: Not implemented,
+                  provisional as of https://github.com/fluxcd/flux2/pull/2092'
+                properties:
+                  namespaceSelectors:
+                    description: NamespaceSelectors is the list of namespace selectors
+                      to which this ACL applies. Items in this list are evaluated
+                      using a logical OR operation.
+                    items:
+                      description: NamespaceSelector selects the namespaces to which
+                        this ACL applies. An empty map of MatchLabels matches all
+                        namespaces in a cluster.
+                      properties:
+                        matchLabels:
+                          additionalProperties:
+                            type: string
+                          description: MatchLabels is a map of {key,value} pairs.
+                            A single {key,value} in the matchLabels map is equivalent
+                            to an element of matchExpressions, whose key field is
+                            "key", the operator is "In", and the values array contains
+                            only "value". The requirements are ANDed.
+                          type: object
+                      type: object
+                    type: array
+                required:
+                - namespaceSelectors
+                type: object
+              interval:
+                description: Interval at which to check the URL for updates.
+                pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
+                type: string
+              passCredentials:
+                description: PassCredentials allows the credentials from the SecretRef
+                  to be passed on to a host that does not match the host as defined
+                  in URL. This may be required if the host of the advertised chart
+                  URLs in the index differ from the defined URL. Enabling this should
+                  be done with caution, as it can potentially result in credentials
+                  getting stolen in a MITM-attack.
+                type: boolean
+              provider:
+                default: generic
+                description: Provider used for authentication, can be 'aws', 'azure',
+                  'gcp' or 'generic'. This field is optional, and only taken into
+                  account if the .spec.type field is set to 'oci'. When not specified,
+                  defaults to 'generic'.
+                enum:
+                - generic
+                - aws
+                - azure
+                - gcp
+                type: string
+              secretRef:
+                description: SecretRef specifies the Secret containing authentication
+                  credentials for the HelmRepository. For HTTP/S basic auth the secret
+                  must contain 'username' and 'password' fields. For TLS the secret
+                  must contain a 'certFile' and 'keyFile', and/or 'caCert' fields.
+                properties:
+                  name:
+                    description: Name of the referent.
+                    type: string
+                required:
+                - name
+                type: object
+              suspend:
+                description: Suspend tells the controller to suspend the reconciliation
+                  of this HelmRepository.
+                type: boolean
+              timeout:
+                default: 60s
+                description: Timeout is used for the index fetch operation for an
+                  HTTPS helm repository, and for remote OCI Repository operations
+                  like pulling for an OCI helm repository. Its default value is 60s.
+                pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m))+$
+                type: string
+              type:
+                description: Type of the HelmRepository. When this field is set to  "oci",
+                  the URL field value must be prefixed with "oci://".
+                enum:
+                - default
+                - oci
+                type: string
+              url:
+                description: URL of the Helm repository, a valid URL contains at least
+                  a protocol and host.
+                type: string
+            required:
+            - interval
+            - url
+            type: object
+          status:
+            default:
+              observedGeneration: -1
+            description: HelmRepositoryStatus records the observed state of the HelmRepository.
+            properties:
+              artifact:
+                description: Artifact represents the last successful HelmRepository
+                  reconciliation.
+                properties:
+                  checksum:
+                    description: Checksum is the SHA256 checksum of the Artifact file.
+                    type: string
+                  lastUpdateTime:
+                    description: LastUpdateTime is the timestamp corresponding to
+                      the last update of the Artifact.
+                    format: date-time
+                    type: string
+                  metadata:
+                    additionalProperties:
+                      type: string
+                    description: Metadata holds upstream information such as OCI annotations.
+                    type: object
+                  path:
+                    description: Path is the relative file path of the Artifact. It
+                      can be used to locate the file in the root of the Artifact storage
+                      on the local file system of the controller managing the Source.
+                    type: string
+                  revision:
+                    description: Revision is a human-readable identifier traceable
+                      in the origin source system. It can be a Git commit SHA, Git
+                      tag, a Helm chart version, etc.
+                    type: string
+                  size:
+                    description: Size is the number of bytes in the file.
+                    format: int64
+                    type: integer
+                  url:
+                    description: URL is the HTTP address of the Artifact as exposed
+                      by the controller managing the Source. It can be used to retrieve
+                      the Artifact for consumption, e.g. by another controller applying
+                      the Artifact contents.
+                    type: string
+                required:
+                - path
+                - url
+                type: object
+              conditions:
+                description: Conditions holds the conditions for the HelmRepository.
+                items:
+                  description: "Condition contains details for one aspect of the current
+                    state of this API Resource. --- This struct is intended for direct
+                    use as an array at the field path .status.conditions.  For example,
+                    \n type FooStatus struct{ // Represents the observations of a
+                    foo's current state. // Known .status.conditions.type are: \"Available\",
+                    \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge
+                    // +listType=map // +listMapKey=type Conditions []metav1.Condition
+                    `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\"
+                    protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields }"
+                  properties:
+                    lastTransitionTime:
+                      description: lastTransitionTime is the last time the condition
+                        transitioned from one status to another. This should be when
+                        the underlying condition changed.  If that is not known, then
+                        using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: message is a human readable message indicating
+                        details about the transition. This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: observedGeneration represents the .metadata.generation
+                        that the condition was set based upon. For instance, if .metadata.generation
+                        is currently 12, but the .status.conditions[x].observedGeneration
+                        is 9, the condition is out of date with respect to the current
+                        state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: reason contains a programmatic identifier indicating
+                        the reason for the condition's last transition. Producers
+                        of specific condition types may define expected values and
+                        meanings for this field, and whether the values are considered
+                        a guaranteed API. The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        --- Many .condition.type values are consistent across resources
+                        like Available, but because arbitrary conditions can be useful
+                        (see .node.status.conditions), the ability to deconflict is
+                        important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              lastHandledReconcileAt:
+                description: LastHandledReconcileAt holds the value of the most recent
+                  reconcile request value, so a change of the annotation value can
+                  be detected.
+                type: string
+              observedGeneration:
+                description: ObservedGeneration is the last observed generation of
+                  the HelmRepository object.
+                format: int64
+                type: integer
+              url:
+                description: URL is the dynamic fetch link for the latest Artifact.
+                  It is provided on a "best effort" basis, and using the precise HelmRepositoryStatus.Artifact
+                  data is recommended.
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.8.0
+  creationTimestamp: null
+  name: ocirepositories.source.toolkit.fluxcd.io
+spec:
+  group: source.toolkit.fluxcd.io
+  names:
+    kind: OCIRepository
+    listKind: OCIRepositoryList
+    plural: ocirepositories
+    shortNames:
+    - ocirepo
+    singular: ocirepository
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .spec.url
+      name: URL
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Ready")].message
+      name: Status
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1beta2
+    schema:
+      openAPIV3Schema:
+        description: OCIRepository is the Schema for the ocirepositories API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: OCIRepositorySpec defines the desired state of OCIRepository
+            properties:
+              certSecretRef:
+                description: "CertSecretRef can be given the name of a secret containing
+                  either or both of \n - a PEM-encoded client certificate (`certFile`)
+                  and private key (`keyFile`); - a PEM-encoded CA certificate (`caFile`)
+                  \n and whichever are supplied, will be used for connecting to the
+                  registry. The client cert and key are useful if you are authenticating
+                  with a certificate; the CA cert is useful if you are using a self-signed
+                  server certificate."
+                properties:
+                  name:
+                    description: Name of the referent.
+                    type: string
+                required:
+                - name
+                type: object
+              ignore:
+                description: Ignore overrides the set of excluded patterns in the
+                  .sourceignore format (which is the same as .gitignore). If not provided,
+                  a default will be used, consult the documentation for your version
+                  to find out what those are.
+                type: string
+              insecure:
+                description: Insecure allows connecting to a non-TLS HTTP container
+                  registry.
+                type: boolean
+              interval:
+                description: The interval at which to check for image updates.
+                pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
+                type: string
+              layerSelector:
+                description: LayerSelector specifies which layer should be extracted
+                  from the OCI artifact. When not specified, the first layer found
+                  in the artifact is selected.
+                properties:
+                  mediaType:
+                    description: MediaType specifies the OCI media type of the layer
+                      which should be extracted from the OCI Artifact. The first layer
+                      matching this type is selected.
+                    type: string
+                  operation:
+                    description: Operation specifies how the selected layer should
+                      be processed. By default, the layer compressed content is extracted
+                      to storage. When the operation is set to 'copy', the layer compressed
+                      content is persisted to storage as it is.
+                    enum:
+                    - extract
+                    - copy
+                    type: string
+                type: object
+              provider:
+                default: generic
+                description: The provider used for authentication, can be 'aws', 'azure',
+                  'gcp' or 'generic'. When not specified, defaults to 'generic'.
+                enum:
+                - generic
+                - aws
+                - azure
+                - gcp
+                type: string
+              ref:
+                description: The OCI reference to pull and monitor for changes, defaults
+                  to the latest tag.
+                properties:
+                  digest:
+                    description: Digest is the image digest to pull, takes precedence
+                      over SemVer. The value should be in the format 'sha256:<HASH>'.
+                    type: string
+                  semver:
+                    description: SemVer is the range of tags to pull selecting the
+                      latest within the range, takes precedence over Tag.
+                    type: string
+                  tag:
+                    description: Tag is the image tag to pull, defaults to latest.
+                    type: string
+                type: object
+              secretRef:
+                description: SecretRef contains the secret name containing the registry
+                  login credentials to resolve image metadata. The secret must be
+                  of type kubernetes.io/dockerconfigjson.
+                properties:
+                  name:
+                    description: Name of the referent.
+                    type: string
+                required:
+                - name
+                type: object
+              serviceAccountName:
+                description: 'ServiceAccountName is the name of the Kubernetes ServiceAccount
+                  used to authenticate the image pull if the service account has attached
+                  pull secrets. For more information: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/#add-imagepullsecrets-to-a-service-account'
+                type: string
+              suspend:
+                description: This flag tells the controller to suspend the reconciliation
+                  of this source.
+                type: boolean
+              timeout:
+                default: 60s
+                description: The timeout for remote OCI Repository operations like
+                  pulling, defaults to 60s.
+                pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m))+$
+                type: string
+              url:
+                description: URL is a reference to an OCI artifact repository hosted
+                  on a remote container registry.
+                pattern: ^oci://.*$
+                type: string
+              verify:
+                description: Verify contains the secret name containing the trusted
+                  public keys used to verify the signature and specifies which provider
+                  to use to check whether OCI image is authentic.
+                properties:
+                  provider:
+                    default: cosign
+                    description: Provider specifies the technology used to sign the
+                      OCI Artifact.
+                    enum:
+                    - cosign
+                    type: string
+                  secretRef:
+                    description: SecretRef specifies the Kubernetes Secret containing
+                      the trusted public keys.
+                    properties:
+                      name:
+                        description: Name of the referent.
+                        type: string
+                    required:
+                    - name
+                    type: object
+                required:
+                - provider
+                type: object
+            required:
+            - interval
+            - url
+            type: object
+          status:
+            default:
+              observedGeneration: -1
+            description: OCIRepositoryStatus defines the observed state of OCIRepository
+            properties:
+              artifact:
+                description: Artifact represents the output of the last successful
+                  OCI Repository sync.
+                properties:
+                  checksum:
+                    description: Checksum is the SHA256 checksum of the Artifact file.
+                    type: string
+                  lastUpdateTime:
+                    description: LastUpdateTime is the timestamp corresponding to
+                      the last update of the Artifact.
+                    format: date-time
+                    type: string
+                  metadata:
+                    additionalProperties:
+                      type: string
+                    description: Metadata holds upstream information such as OCI annotations.
+                    type: object
+                  path:
+                    description: Path is the relative file path of the Artifact. It
+                      can be used to locate the file in the root of the Artifact storage
+                      on the local file system of the controller managing the Source.
+                    type: string
+                  revision:
+                    description: Revision is a human-readable identifier traceable
+                      in the origin source system. It can be a Git commit SHA, Git
+                      tag, a Helm chart version, etc.
+                    type: string
+                  size:
+                    description: Size is the number of bytes in the file.
+                    format: int64
+                    type: integer
+                  url:
+                    description: URL is the HTTP address of the Artifact as exposed
+                      by the controller managing the Source. It can be used to retrieve
+                      the Artifact for consumption, e.g. by another controller applying
+                      the Artifact contents.
+                    type: string
+                required:
+                - path
+                - url
+                type: object
+              conditions:
+                description: Conditions holds the conditions for the OCIRepository.
+                items:
+                  description: "Condition contains details for one aspect of the current
+                    state of this API Resource. --- This struct is intended for direct
+                    use as an array at the field path .status.conditions.  For example,
+                    \n type FooStatus struct{ // Represents the observations of a
+                    foo's current state. // Known .status.conditions.type are: \"Available\",
+                    \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge
+                    // +listType=map // +listMapKey=type Conditions []metav1.Condition
+                    `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\"
+                    protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields }"
+                  properties:
+                    lastTransitionTime:
+                      description: lastTransitionTime is the last time the condition
+                        transitioned from one status to another. This should be when
+                        the underlying condition changed.  If that is not known, then
+                        using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: message is a human readable message indicating
+                        details about the transition. This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: observedGeneration represents the .metadata.generation
+                        that the condition was set based upon. For instance, if .metadata.generation
+                        is currently 12, but the .status.conditions[x].observedGeneration
+                        is 9, the condition is out of date with respect to the current
+                        state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: reason contains a programmatic identifier indicating
+                        the reason for the condition's last transition. Producers
+                        of specific condition types may define expected values and
+                        meanings for this field, and whether the values are considered
+                        a guaranteed API. The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        --- Many .condition.type values are consistent across resources
+                        like Available, but because arbitrary conditions can be useful
+                        (see .node.status.conditions), the ability to deconflict is
+                        important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              contentConfigChecksum:
+                description: "ContentConfigChecksum is a checksum of all the configurations
+                  related to the content of the source artifact: - .spec.ignore -
+                  .spec.layerSelector observed in .status.observedGeneration version
+                  of the object. This can be used to determine if the content configuration
+                  has changed and the artifact needs to be rebuilt. It has the format
+                  of `<algo>:<checksum>`, for example: `sha256:<checksum>`. \n Deprecated:
+                  Replaced with explicit fields for observed artifact content config
+                  in the status."
+                type: string
+              lastHandledReconcileAt:
+                description: LastHandledReconcileAt holds the value of the most recent
+                  reconcile request value, so a change of the annotation value can
+                  be detected.
+                type: string
+              observedGeneration:
+                description: ObservedGeneration is the last observed generation.
+                format: int64
+                type: integer
+              observedIgnore:
+                description: ObservedIgnore is the observed exclusion patterns used
+                  for constructing the source artifact.
+                type: string
+              observedLayerSelector:
+                description: ObservedLayerSelector is the observed layer selector
+                  used for constructing the source artifact.
+                properties:
+                  mediaType:
+                    description: MediaType specifies the OCI media type of the layer
+                      which should be extracted from the OCI Artifact. The first layer
+                      matching this type is selected.
+                    type: string
+                  operation:
+                    description: Operation specifies how the selected layer should
+                      be processed. By default, the layer compressed content is extracted
+                      to storage. When the operation is set to 'copy', the layer compressed
+                      content is persisted to storage as it is.
+                    enum:
+                    - extract
+                    - copy
+                    type: string
+                type: object
+              url:
+                description: URL is the download link for the artifact output of the
+                  last OCI Repository sync.
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.4.1
+  creationTimestamp: null
+  name: redpandas.cluster.redpanda.com
+spec:
+  group: cluster.redpanda.com
+  names:
+    kind: Redpanda
+    listKind: RedpandaList
+    plural: redpandas
+    shortNames:
+    - rp
+    singular: redpanda
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Ready")].message
+      name: Status
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: Redpanda is the Schema for the redpanda API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: RedpandaSpec defines the desired state of Redpanda
+            properties:
+              chartRef:
+                description: ChartRef defines chart details including repository
+                properties:
+                  chartName:
+                    description: ChartName is the chart to use
+                    type: string
+                  chartVersion:
+                    description: ChartVersion defines the helm chart version to use
+                    type: string
+                  helmRepositoryName:
+                    description: HelmRepositoryName defines the repository to use,
+                      defaults to redpanda if not defined
+                    type: string
+                  timeout:
+                    description: Timeout is the time to wait for any individual Kubernetes
+                      operation (like Jobs for hooks) during the performance of a
+                      Helm action. Defaults to '15m0s'.
+                    pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
+                    type: string
+                  upgrade:
+                    description: Upgrade contains the details for handling upgrades
+                      including failures
+                    properties:
+                      cleanupOnFail:
+                        type: boolean
+                      force:
+                        type: boolean
+                      preserveValues:
+                        type: boolean
+                      remediation:
+                        description: UpgradeRemediation holds the configuration for
+                          Helm upgrade remediation.
+                        properties:
+                          ignoreTestFailures:
+                            description: IgnoreTestFailures tells the controller to
+                              skip remediation when the Helm tests are run after an
+                              upgrade action but fail. Defaults to 'Test.IgnoreFailures'.
+                            type: boolean
+                          remediateLastFailure:
+                            description: RemediateLastFailure tells the controller
+                              to remediate the last failure, when no retries remain.
+                              Defaults to 'false' unless 'Retries' is greater than
+                              0.
+                            type: boolean
+                          retries:
+                            description: Retries is the number of retries that should
+                              be attempted on failures before bailing. Remediation,
+                              using 'Strategy', is performed between each attempt.
+                              Defaults to '0', a negative integer equals to unlimited
+                              retries.
+                            type: integer
+                          strategy:
+                            description: Strategy to use for failure remediation.
+                              Defaults to 'rollback'.
+                            enum:
+                            - rollback
+                            - uninstall
+                            type: string
+                        type: object
+                    type: object
+                type: object
+              clusterSpec:
+                description: ClusterSpec defines the values to use in the cluster
+                properties:
+                  auth:
+                    description: Auth is a top level field of the values file
+                    properties:
+                      sasl:
+                        description: SASL is a top level field of the values file
+                        properties:
+                          enabled:
+                            type: boolean
+                          mechanism:
+                            type: string
+                          secretRef:
+                            type: string
+                          users:
+                            items:
+                              description: UsersItems is a top level field of the
+                                values file
+                              properties:
+                                mechanism:
+                                  type: string
+                                name:
+                                  type: string
+                                password:
+                                  type: string
+                              type: object
+                            type: array
+                        required:
+                        - enabled
+                        - users
+                        type: object
+                    required:
+                    - sasl
+                    type: object
+                  clusterDomain:
+                    description: ClusterDomain is the override to give your redpanda
+                      release
+                    type: string
+                  commonLabels:
+                    additionalProperties:
+                      type: string
+                    description: CommonLabels is the override to give your redpanda
+                      release
+                    type: object
+                  config:
+                    description: Config is a top level field of the values file
+                    properties:
+                      cluster:
+                        type: object
+                        x-kubernetes-preserve-unknown-fields: true
+                      node:
+                        type: object
+                        x-kubernetes-preserve-unknown-fields: true
+                      tunable:
+                        type: object
+                        x-kubernetes-preserve-unknown-fields: true
+                    type: object
+                  console:
+                    properties:
+                      configMap:
+                        properties:
+                          create:
+                            type: boolean
+                        required:
+                        - create
+                        type: object
+                      console:
+                        type: object
+                        x-kubernetes-preserve-unknown-fields: true
+                      deployment:
+                        properties:
+                          create:
+                            type: boolean
+                        required:
+                        - create
+                        type: object
+                      enabled:
+                        type: boolean
+                      secret:
+                        properties:
+                          create:
+                            type: boolean
+                        required:
+                        - create
+                        type: object
+                    type: object
+                  external:
+                    description: External is a top level field of the values file
+                    properties:
+                      addresses:
+                        items:
+                          type: string
+                        type: array
+                      domain:
+                        type: string
+                      enabled:
+                        type: boolean
+                      externalDNS:
+                        properties:
+                          enabled:
+                            type: boolean
+                        required:
+                        - enabled
+                        type: object
+                      type:
+                        type: string
+                    type: object
+                  fullNameOverride:
+                    description: FullNameOverride is the override to give your redpanda
+                      release
+                    type: string
+                  image:
+                    description: Image defines the container image to use for the
+                      redpanda cluster
+                    properties:
+                      pullPolicy:
+                        type: string
+                      repository:
+                        type: string
+                      tag:
+                        type: string
+                    type: object
+                  imagePullSecrets:
+                    items:
+                      description: LocalObjectReference contains enough information
+                        to let you locate the referenced object inside the same namespace.
+                      properties:
+                        name:
+                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                            TODO: Add other useful fields. apiVersion, kind, uid?'
+                          type: string
+                      type: object
+                    type: array
+                  license_key:
+                    type: string
+                  license_secret_ref:
+                    description: LicenseSecretRef is a top level field of the values
+                      file
+                    properties:
+                      secret_key:
+                        type: string
+                      secret_name:
+                        type: string
+                    type: object
+                  listeners:
+                    description: Listeners is a top level field of the values file
+                    properties:
+                      admin:
+                        description: Admin is a top level field of the values file
+                        properties:
+                          external:
+                            additionalProperties:
+                              properties:
+                                advertisedPorts:
+                                  items:
+                                    type: integer
+                                  type: array
+                                port:
+                                  type: integer
+                                tls:
+                                  description: ListenerTLS is a top level field of
+                                    the values file
+                                  properties:
+                                    cert:
+                                      type: string
+                                    enabled:
+                                      type: boolean
+                                    requireClientAuth:
+                                      type: boolean
+                                  type: object
+                              type: object
+                            type: object
+                          port:
+                            type: integer
+                          tls:
+                            description: ListenerTLS is a top level field of the values
+                              file
+                            properties:
+                              cert:
+                                type: string
+                              enabled:
+                                type: boolean
+                              requireClientAuth:
+                                type: boolean
+                            type: object
+                        type: object
+                      http:
+                        description: HTTP is a top level field of the values file`
+                        properties:
+                          authenticationMethod:
+                            type: string
+                          enabled:
+                            type: boolean
+                          external:
+                            additionalProperties:
+                              properties:
+                                advertisedPorts:
+                                  items:
+                                    type: integer
+                                  type: array
+                                port:
+                                  type: integer
+                                tls:
+                                  description: ListenerTLS is a top level field of
+                                    the values file
+                                  properties:
+                                    cert:
+                                      type: string
+                                    enabled:
+                                      type: boolean
+                                    requireClientAuth:
+                                      type: boolean
+                                  type: object
+                              type: object
+                            type: object
+                          kafkaEndpoint:
+                            type: string
+                          port:
+                            type: integer
+                          tls:
+                            description: ListenerTLS is a top level field of the values
+                              file
+                            properties:
+                              cert:
+                                type: string
+                              enabled:
+                                type: boolean
+                              requireClientAuth:
+                                type: boolean
+                            type: object
+                        type: object
+                      kafka:
+                        description: Kafka is a top level field of the values file
+                        properties:
+                          authenticationMethod:
+                            type: string
+                          external:
+                            additionalProperties:
+                              properties:
+                                advertisedPorts:
+                                  items:
+                                    type: integer
+                                  type: array
+                                port:
+                                  type: integer
+                                tls:
+                                  description: ListenerTLS is a top level field of
+                                    the values file
+                                  properties:
+                                    cert:
+                                      type: string
+                                    enabled:
+                                      type: boolean
+                                    requireClientAuth:
+                                      type: boolean
+                                  type: object
+                              type: object
+                            type: object
+                          port:
+                            type: integer
+                          tls:
+                            description: ListenerTLS is a top level field of the values
+                              file
+                            properties:
+                              cert:
+                                type: string
+                              enabled:
+                                type: boolean
+                              requireClientAuth:
+                                type: boolean
+                            type: object
+                        type: object
+                      rpc:
+                        description: RPC is a top level field of the values file
+                        properties:
+                          port:
+                            type: integer
+                          tls:
+                            description: ListenerTLS is a top level field of the values
+                              file
+                            properties:
+                              cert:
+                                type: string
+                              enabled:
+                                type: boolean
+                              requireClientAuth:
+                                type: boolean
+                            type: object
+                        type: object
+                      schemaRegistry:
+                        description: SchemaRegistry is a top level field of the values
+                          file
+                        properties:
+                          authenticationMethod:
+                            type: string
+                          enabled:
+                            type: boolean
+                          external:
+                            additionalProperties:
+                              properties:
+                                advertisedPorts:
+                                  items:
+                                    type: integer
+                                  type: array
+                                port:
+                                  type: integer
+                                tls:
+                                  description: ListenerTLS is a top level field of
+                                    the values file
+                                  properties:
+                                    cert:
+                                      type: string
+                                    enabled:
+                                      type: boolean
+                                    requireClientAuth:
+                                      type: boolean
+                                  type: object
+                              type: object
+                            type: object
+                          kafkaEndpoint:
+                            type: string
+                          port:
+                            type: integer
+                          tls:
+                            description: ListenerTLS is a top level field of the values
+                              file
+                            properties:
+                              cert:
+                                type: string
+                              enabled:
+                                type: boolean
+                              requireClientAuth:
+                                type: boolean
+                            type: object
+                        type: object
+                    type: object
+                  logging:
+                    description: Logging is a top level field of the values file
+                    properties:
+                      logLevel:
+                        type: string
+                      usageStats:
+                        properties:
+                          clusterId:
+                            type: string
+                          enabled:
+                            type: boolean
+                          organization:
+                            type: string
+                        required:
+                        - enabled
+                        type: object
+                    required:
+                    - logLevel
+                    - usageStats
+                    type: object
+                  monitoring:
+                    properties:
+                      commonLabels:
+                        additionalProperties:
+                          type: string
+                        type: object
+                      enabled:
+                        type: boolean
+                      scrapeInterval:
+                        type: string
+                    required:
+                    - enabled
+                    type: object
+                  nameOverride:
+                    description: NameOverride is the override to give your redpanda
+                      release
+                    type: string
+                  nodeSelector:
+                    additionalProperties:
+                      type: string
+                    description: NodeSelector is the override to give your redpanda
+                      release
+                    type: object
+                  post_install_job:
+                    description: PostInstallJob is a top level field of the values
+                      file
+                    properties:
+                      annotations:
+                        additionalProperties:
+                          type: string
+                        type: object
+                      enabled:
+                        type: boolean
+                      labels:
+                        additionalProperties:
+                          type: string
+                        type: object
+                      resources:
+                        description: ResourceRequirements describes the compute resource
+                          requirements.
+                        properties:
+                          claims:
+                            description: "Claims lists the names of resources, defined
+                              in spec.resourceClaims, that are used by this container.
+                              \n This is an alpha field and requires enabling the
+                              DynamicResourceAllocation feature gate. \n This field
+                              is immutable."
+                            items:
+                              description: ResourceClaim references one entry in PodSpec.ResourceClaims.
+                              properties:
+                                name:
+                                  description: Name must match the name of one entry
+                                    in pod.spec.resourceClaims of the Pod where this
+                                    field is used. It makes that resource available
+                                    inside a container.
+                                  type: string
+                              required:
+                              - name
+                              type: object
+                            type: array
+                            x-kubernetes-list-map-keys:
+                            - name
+                            x-kubernetes-list-type: map
+                          limits:
+                            additionalProperties:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            description: 'Limits describes the maximum amount of compute
+                              resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                            type: object
+                          requests:
+                            additionalProperties:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            description: 'Requests describes the minimum amount of
+                              compute resources required. If Requests is omitted for
+                              a container, it defaults to Limits if that is explicitly
+                              specified, otherwise to an implementation-defined value.
+                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                            type: object
+                        type: object
+                    required:
+                    - enabled
+                    type: object
+                  post_upgrade_job:
+                    description: PostUpgradeJob is a top level field of the values
+                      file
+                    properties:
+                      annotations:
+                        additionalProperties:
+                          type: string
+                        type: object
+                      enabled:
+                        type: boolean
+                      extraEnv:
+                        items:
+                          description: EnvVar represents an environment variable present
+                            in a Container.
+                          properties:
+                            name:
+                              description: Name of the environment variable. Must
+                                be a C_IDENTIFIER.
+                              type: string
+                            value:
+                              description: 'Variable references $(VAR_NAME) are expanded
+                                using the previously defined environment variables
+                                in the container and any service environment variables.
+                                If a variable cannot be resolved, the reference in
+                                the input string will be unchanged. Double $$ are
+                                reduced to a single $, which allows for escaping the
+                                $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce
+                                the string literal "$(VAR_NAME)". Escaped references
+                                will never be expanded, regardless of whether the
+                                variable exists or not. Defaults to "".'
+                              type: string
+                            valueFrom:
+                              description: Source for the environment variable's value.
+                                Cannot be used if value is not empty.
+                              properties:
+                                configMapKeyRef:
+                                  description: Selects a key of a ConfigMap.
+                                  properties:
+                                    key:
+                                      description: The key to select.
+                                      type: string
+                                    name:
+                                      description: 'Name of the referent. More info:
+                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Add other useful fields. apiVersion,
+                                        kind, uid?'
+                                      type: string
+                                    optional:
+                                      description: Specify whether the ConfigMap or
+                                        its key must be defined
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
+                                fieldRef:
+                                  description: 'Selects a field of the pod: supports
+                                    metadata.name, metadata.namespace, `metadata.labels[''<KEY>'']`,
+                                    `metadata.annotations[''<KEY>'']`, spec.nodeName,
+                                    spec.serviceAccountName, status.hostIP, status.podIP,
+                                    status.podIPs.'
+                                  properties:
+                                    apiVersion:
+                                      description: Version of the schema the FieldPath
+                                        is written in terms of, defaults to "v1".
+                                      type: string
+                                    fieldPath:
+                                      description: Path of the field to select in
+                                        the specified API version.
+                                      type: string
+                                  required:
+                                  - fieldPath
+                                  type: object
+                                resourceFieldRef:
+                                  description: 'Selects a resource of the container:
+                                    only resources limits and requests (limits.cpu,
+                                    limits.memory, limits.ephemeral-storage, requests.cpu,
+                                    requests.memory and requests.ephemeral-storage)
+                                    are currently supported.'
+                                  properties:
+                                    containerName:
+                                      description: 'Container name: required for volumes,
+                                        optional for env vars'
+                                      type: string
+                                    divisor:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Specifies the output format of
+                                        the exposed resources, defaults to "1"
+                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                      x-kubernetes-int-or-string: true
+                                    resource:
+                                      description: 'Required: resource to select'
+                                      type: string
+                                  required:
+                                  - resource
+                                  type: object
+                                secretKeyRef:
+                                  description: Selects a key of a secret in the pod's
+                                    namespace
+                                  properties:
+                                    key:
+                                      description: The key of the secret to select
+                                        from.  Must be a valid secret key.
+                                      type: string
+                                    name:
+                                      description: 'Name of the referent. More info:
+                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Add other useful fields. apiVersion,
+                                        kind, uid?'
+                                      type: string
+                                    optional:
+                                      description: Specify whether the Secret or its
+                                        key must be defined
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
+                              type: object
+                          required:
+                          - name
+                          type: object
+                        type: array
+                      extraEnvFrom:
+                        items:
+                          description: EnvFromSource represents the source of a set
+                            of ConfigMaps
+                          properties:
+                            configMapRef:
+                              description: The ConfigMap to select from
+                              properties:
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Add other useful fields. apiVersion, kind,
+                                    uid?'
+                                  type: string
+                                optional:
+                                  description: Specify whether the ConfigMap must
+                                    be defined
+                                  type: boolean
+                              type: object
+                            prefix:
+                              description: An optional identifier to prepend to each
+                                key in the ConfigMap. Must be a C_IDENTIFIER.
+                              type: string
+                            secretRef:
+                              description: The Secret to select from
+                              properties:
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Add other useful fields. apiVersion, kind,
+                                    uid?'
+                                  type: string
+                                optional:
+                                  description: Specify whether the Secret must be
+                                    defined
+                                  type: boolean
+                              type: object
+                          type: object
+                        type: array
+                      labels:
+                        additionalProperties:
+                          type: string
+                        type: object
+                      resources:
+                        description: ResourceRequirements describes the compute resource
+                          requirements.
+                        properties:
+                          claims:
+                            description: "Claims lists the names of resources, defined
+                              in spec.resourceClaims, that are used by this container.
+                              \n This is an alpha field and requires enabling the
+                              DynamicResourceAllocation feature gate. \n This field
+                              is immutable."
+                            items:
+                              description: ResourceClaim references one entry in PodSpec.ResourceClaims.
+                              properties:
+                                name:
+                                  description: Name must match the name of one entry
+                                    in pod.spec.resourceClaims of the Pod where this
+                                    field is used. It makes that resource available
+                                    inside a container.
+                                  type: string
+                              required:
+                              - name
+                              type: object
+                            type: array
+                            x-kubernetes-list-map-keys:
+                            - name
+                            x-kubernetes-list-type: map
+                          limits:
+                            additionalProperties:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            description: 'Limits describes the maximum amount of compute
+                              resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                            type: object
+                          requests:
+                            additionalProperties:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            description: 'Requests describes the minimum amount of
+                              compute resources required. If Requests is omitted for
+                              a container, it defaults to Limits if that is explicitly
+                              specified, otherwise to an implementation-defined value.
+                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                            type: object
+                        type: object
+                    required:
+                    - enabled
+                    type: object
+                  rackAwareness:
+                    description: RackAwareness is a top level field of the values
+                      file
+                    properties:
+                      enabled:
+                        type: boolean
+                      nodeAnnotation:
+                        type: string
+                    required:
+                    - enabled
+                    - nodeAnnotation
+                    type: object
+                  rbac:
+                    properties:
+                      annotations:
+                        additionalProperties:
+                          type: string
+                        type: object
+                      enabled:
+                        type: boolean
+                    required:
+                    - enabled
+                    type: object
+                  resources:
+                    properties:
+                      cpu:
+                        properties:
+                          cores:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          overprovisioned:
+                            type: boolean
+                        type: object
+                      memory:
+                        properties:
+                          container:
+                            properties:
+                              max:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              min:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                            type: object
+                          enable_memory_locking:
+                            type: boolean
+                          redpanda:
+                            properties:
+                              memory:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              reserveMemory:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                            required:
+                            - memory
+                            - reserveMemory
+                            type: object
+                        required:
+                        - container
+                        type: object
+                    type: object
+                  serviceAccount:
+                    properties:
+                      annotations:
+                        additionalProperties:
+                          type: string
+                        type: object
+                      create:
+                        type: boolean
+                      name:
+                        type: string
+                    required:
+                    - create
+                    - name
+                    type: object
+                  statefulset:
+                    description: Statefulset is a top level field of the values file
+                    properties:
+                      additionalRedpandaCmdFlags:
+                        items:
+                          type: string
+                        type: array
+                      annotations:
+                        additionalProperties:
+                          type: string
+                        type: object
+                      budget:
+                        description: Budget is a top level field of the values file
+                        properties:
+                          maxUnavailable:
+                            type: integer
+                        required:
+                        - maxUnavailable
+                        type: object
+                      extraVolumeMounts:
+                        type: string
+                      extraVolumes:
+                        type: string
+                      initContainerImage:
+                        properties:
+                          repository:
+                            type: string
+                          tag:
+                            type: string
+                        type: object
+                      initContainers:
+                        properties:
+                          configurator:
+                            properties:
+                              extraVolumeMounts:
+                                type: string
+                              resources:
+                                description: ResourceRequirements describes the compute
+                                  resource requirements.
+                                properties:
+                                  claims:
+                                    description: "Claims lists the names of resources,
+                                      defined in spec.resourceClaims, that are used
+                                      by this container. \n This is an alpha field
+                                      and requires enabling the DynamicResourceAllocation
+                                      feature gate. \n This field is immutable."
+                                    items:
+                                      description: ResourceClaim references one entry
+                                        in PodSpec.ResourceClaims.
+                                      properties:
+                                        name:
+                                          description: Name must match the name of
+                                            one entry in pod.spec.resourceClaims of
+                                            the Pod where this field is used. It makes
+                                            that resource available inside a container.
+                                          type: string
+                                      required:
+                                      - name
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-map-keys:
+                                    - name
+                                    x-kubernetes-list-type: map
+                                  limits:
+                                    additionalProperties:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                      x-kubernetes-int-or-string: true
+                                    description: 'Limits describes the maximum amount
+                                      of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                    type: object
+                                  requests:
+                                    additionalProperties:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                      x-kubernetes-int-or-string: true
+                                    description: 'Requests describes the minimum amount
+                                      of compute resources required. If Requests is
+                                      omitted for a container, it defaults to Limits
+                                      if that is explicitly specified, otherwise to
+                                      an implementation-defined value. More info:
+                                      https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                    type: object
+                                type: object
+                            type: object
+                          extraInitContainers:
+                            type: string
+                          setDataDirOwnership:
+                            properties:
+                              enabled:
+                                type: boolean
+                              extraVolumeMounts:
+                                type: string
+                              resources:
+                                description: ResourceRequirements describes the compute
+                                  resource requirements.
+                                properties:
+                                  claims:
+                                    description: "Claims lists the names of resources,
+                                      defined in spec.resourceClaims, that are used
+                                      by this container. \n This is an alpha field
+                                      and requires enabling the DynamicResourceAllocation
+                                      feature gate. \n This field is immutable."
+                                    items:
+                                      description: ResourceClaim references one entry
+                                        in PodSpec.ResourceClaims.
+                                      properties:
+                                        name:
+                                          description: Name must match the name of
+                                            one entry in pod.spec.resourceClaims of
+                                            the Pod where this field is used. It makes
+                                            that resource available inside a container.
+                                          type: string
+                                      required:
+                                      - name
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-map-keys:
+                                    - name
+                                    x-kubernetes-list-type: map
+                                  limits:
+                                    additionalProperties:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                      x-kubernetes-int-or-string: true
+                                    description: 'Limits describes the maximum amount
+                                      of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                    type: object
+                                  requests:
+                                    additionalProperties:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                      x-kubernetes-int-or-string: true
+                                    description: 'Requests describes the minimum amount
+                                      of compute resources required. If Requests is
+                                      omitted for a container, it defaults to Limits
+                                      if that is explicitly specified, otherwise to
+                                      an implementation-defined value. More info:
+                                      https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                    type: object
+                                type: object
+                            type: object
+                          setTieredStorageCacheDirOwnership:
+                            properties:
+                              extraVolumeMounts:
+                                type: string
+                              resources:
+                                description: ResourceRequirements describes the compute
+                                  resource requirements.
+                                properties:
+                                  claims:
+                                    description: "Claims lists the names of resources,
+                                      defined in spec.resourceClaims, that are used
+                                      by this container. \n This is an alpha field
+                                      and requires enabling the DynamicResourceAllocation
+                                      feature gate. \n This field is immutable."
+                                    items:
+                                      description: ResourceClaim references one entry
+                                        in PodSpec.ResourceClaims.
+                                      properties:
+                                        name:
+                                          description: Name must match the name of
+                                            one entry in pod.spec.resourceClaims of
+                                            the Pod where this field is used. It makes
+                                            that resource available inside a container.
+                                          type: string
+                                      required:
+                                      - name
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-map-keys:
+                                    - name
+                                    x-kubernetes-list-type: map
+                                  limits:
+                                    additionalProperties:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                      x-kubernetes-int-or-string: true
+                                    description: 'Limits describes the maximum amount
+                                      of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                    type: object
+                                  requests:
+                                    additionalProperties:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                      x-kubernetes-int-or-string: true
+                                    description: 'Requests describes the minimum amount
+                                      of compute resources required. If Requests is
+                                      omitted for a container, it defaults to Limits
+                                      if that is explicitly specified, otherwise to
+                                      an implementation-defined value. More info:
+                                      https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                    type: object
+                                type: object
+                            type: object
+                          tuning:
+                            description: Tuning is a top level field of the values
+                              file
+                            properties:
+                              ballast_file_path:
+                                type: string
+                              ballast_file_size:
+                                type: string
+                              extraVolumeMounts:
+                                type: string
+                              resources:
+                                description: ResourceRequirements describes the compute
+                                  resource requirements.
+                                properties:
+                                  claims:
+                                    description: "Claims lists the names of resources,
+                                      defined in spec.resourceClaims, that are used
+                                      by this container. \n This is an alpha field
+                                      and requires enabling the DynamicResourceAllocation
+                                      feature gate. \n This field is immutable."
+                                    items:
+                                      description: ResourceClaim references one entry
+                                        in PodSpec.ResourceClaims.
+                                      properties:
+                                        name:
+                                          description: Name must match the name of
+                                            one entry in pod.spec.resourceClaims of
+                                            the Pod where this field is used. It makes
+                                            that resource available inside a container.
+                                          type: string
+                                      required:
+                                      - name
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-map-keys:
+                                    - name
+                                    x-kubernetes-list-type: map
+                                  limits:
+                                    additionalProperties:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                      x-kubernetes-int-or-string: true
+                                    description: 'Limits describes the maximum amount
+                                      of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                    type: object
+                                  requests:
+                                    additionalProperties:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                      x-kubernetes-int-or-string: true
+                                    description: 'Requests describes the minimum amount
+                                      of compute resources required. If Requests is
+                                      omitted for a container, it defaults to Limits
+                                      if that is explicitly specified, otherwise to
+                                      an implementation-defined value. More info:
+                                      https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                    type: object
+                                type: object
+                              tune_aio_events:
+                                type: boolean
+                              tune_ballast_file:
+                                type: boolean
+                              tune_clocksource:
+                                type: boolean
+                              well_known_io:
+                                type: string
+                            type: object
+                        type: object
+                      livenessProbe:
+                        description: LivenessProbe is a top level field of the values
+                          file
+                        properties:
+                          failureThreshold:
+                            type: integer
+                          initialDelaySeconds:
+                            type: integer
+                          periodSeconds:
+                            type: integer
+                        required:
+                        - failureThreshold
+                        - initialDelaySeconds
+                        - periodSeconds
+                        type: object
+                      nodeSelector:
+                        additionalProperties:
+                          type: string
+                        type: object
+                      podAffinity:
+                        description: Pod affinity is a group of inter pod affinity
+                          scheduling rules.
+                        properties:
+                          preferredDuringSchedulingIgnoredDuringExecution:
+                            description: The scheduler will prefer to schedule pods
+                              to nodes that satisfy the affinity expressions specified
+                              by this field, but it may choose a node that violates
+                              one or more of the expressions. The node that is most
+                              preferred is the one with the greatest sum of weights,
+                              i.e. for each node that meets all of the scheduling
+                              requirements (resource request, requiredDuringScheduling
+                              affinity expressions, etc.), compute a sum by iterating
+                              through the elements of this field and adding "weight"
+                              to the sum if the node has pods which matches the corresponding
+                              podAffinityTerm; the node(s) with the highest sum are
+                              the most preferred.
+                            items:
+                              description: The weights of all of the matched WeightedPodAffinityTerm
+                                fields are added per-node to find the most preferred
+                                node(s)
+                              properties:
+                                podAffinityTerm:
+                                  description: Required. A pod affinity term, associated
+                                    with the corresponding weight.
+                                  properties:
+                                    labelSelector:
+                                      description: A label query over a set of resources,
+                                        in this case pods.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: A label selector requirement
+                                              is a selector that contains values,
+                                              a key, and an operator that relates
+                                              the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: operator represents a
+                                                  key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists
+                                                  and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: values is an array of
+                                                  string values. If the operator is
+                                                  In or NotIn, the values array must
+                                                  be non-empty. If the operator is
+                                                  Exists or DoesNotExist, the values
+                                                  array must be empty. This array
+                                                  is replaced during a strategic merge
+                                                  patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: matchLabels is a map of {key,value}
+                                            pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions,
+                                            whose key field is "key", the operator
+                                            is "In", and the values array contains
+                                            only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                    namespaceSelector:
+                                      description: A label query over the set of namespaces
+                                        that the term applies to. The term is applied
+                                        to the union of the namespaces selected by
+                                        this field and the ones listed in the namespaces
+                                        field. null selector and null or empty namespaces
+                                        list means "this pod's namespace". An empty
+                                        selector ({}) matches all namespaces.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: A label selector requirement
+                                              is a selector that contains values,
+                                              a key, and an operator that relates
+                                              the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: operator represents a
+                                                  key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists
+                                                  and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: values is an array of
+                                                  string values. If the operator is
+                                                  In or NotIn, the values array must
+                                                  be non-empty. If the operator is
+                                                  Exists or DoesNotExist, the values
+                                                  array must be empty. This array
+                                                  is replaced during a strategic merge
+                                                  patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: matchLabels is a map of {key,value}
+                                            pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions,
+                                            whose key field is "key", the operator
+                                            is "In", and the values array contains
+                                            only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                    namespaces:
+                                      description: namespaces specifies a static list
+                                        of namespace names that the term applies to.
+                                        The term is applied to the union of the namespaces
+                                        listed in this field and the ones selected
+                                        by namespaceSelector. null or empty namespaces
+                                        list and null namespaceSelector means "this
+                                        pod's namespace".
+                                      items:
+                                        type: string
+                                      type: array
+                                    topologyKey:
+                                      description: This pod should be co-located (affinity)
+                                        or not co-located (anti-affinity) with the
+                                        pods matching the labelSelector in the specified
+                                        namespaces, where co-located is defined as
+                                        running on a node whose value of the label
+                                        with key topologyKey matches that of any node
+                                        on which any of the selected pods is running.
+                                        Empty topologyKey is not allowed.
+                                      type: string
+                                  required:
+                                  - topologyKey
+                                  type: object
+                                weight:
+                                  description: weight associated with matching the
+                                    corresponding podAffinityTerm, in the range 1-100.
+                                  format: int32
+                                  type: integer
+                              required:
+                              - podAffinityTerm
+                              - weight
+                              type: object
+                            type: array
+                          requiredDuringSchedulingIgnoredDuringExecution:
+                            description: If the affinity requirements specified by
+                              this field are not met at scheduling time, the pod will
+                              not be scheduled onto the node. If the affinity requirements
+                              specified by this field cease to be met at some point
+                              during pod execution (e.g. due to a pod label update),
+                              the system may or may not try to eventually evict the
+                              pod from its node. When there are multiple elements,
+                              the lists of nodes corresponding to each podAffinityTerm
+                              are intersected, i.e. all terms must be satisfied.
+                            items:
+                              description: Defines a set of pods (namely those matching
+                                the labelSelector relative to the given namespace(s))
+                                that this pod should be co-located (affinity) or not
+                                co-located (anti-affinity) with, where co-located
+                                is defined as running on a node whose value of the
+                                label with key <topologyKey> matches that of any node
+                                on which a pod of the set of pods is running
+                              properties:
+                                labelSelector:
+                                  description: A label query over a set of resources,
+                                    in this case pods.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
+                                      items:
+                                        description: A label selector requirement
+                                          is a selector that contains values, a key,
+                                          and an operator that relates the key and
+                                          values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that
+                                              the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: operator represents a key's
+                                              relationship to a set of values. Valid
+                                              operators are In, NotIn, Exists and
+                                              DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: values is an array of string
+                                              values. If the operator is In or NotIn,
+                                              the values array must be non-empty.
+                                              If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This
+                                              array is replaced during a strategic
+                                              merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: matchLabels is a map of {key,value}
+                                        pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions,
+                                        whose key field is "key", the operator is
+                                        "In", and the values array contains only "value".
+                                        The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                namespaceSelector:
+                                  description: A label query over the set of namespaces
+                                    that the term applies to. The term is applied
+                                    to the union of the namespaces selected by this
+                                    field and the ones listed in the namespaces field.
+                                    null selector and null or empty namespaces list
+                                    means "this pod's namespace". An empty selector
+                                    ({}) matches all namespaces.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
+                                      items:
+                                        description: A label selector requirement
+                                          is a selector that contains values, a key,
+                                          and an operator that relates the key and
+                                          values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that
+                                              the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: operator represents a key's
+                                              relationship to a set of values. Valid
+                                              operators are In, NotIn, Exists and
+                                              DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: values is an array of string
+                                              values. If the operator is In or NotIn,
+                                              the values array must be non-empty.
+                                              If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This
+                                              array is replaced during a strategic
+                                              merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: matchLabels is a map of {key,value}
+                                        pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions,
+                                        whose key field is "key", the operator is
+                                        "In", and the values array contains only "value".
+                                        The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                namespaces:
+                                  description: namespaces specifies a static list
+                                    of namespace names that the term applies to. The
+                                    term is applied to the union of the namespaces
+                                    listed in this field and the ones selected by
+                                    namespaceSelector. null or empty namespaces list
+                                    and null namespaceSelector means "this pod's namespace".
+                                  items:
+                                    type: string
+                                  type: array
+                                topologyKey:
+                                  description: This pod should be co-located (affinity)
+                                    or not co-located (anti-affinity) with the pods
+                                    matching the labelSelector in the specified namespaces,
+                                    where co-located is defined as running on a node
+                                    whose value of the label with key topologyKey
+                                    matches that of any node on which any of the selected
+                                    pods is running. Empty topologyKey is not allowed.
+                                  type: string
+                              required:
+                              - topologyKey
+                              type: object
+                            type: array
+                        type: object
+                      podAntiAffinity:
+                        description: Pod anti affinity is a group of inter pod anti
+                          affinity scheduling rules.
+                        properties:
+                          preferredDuringSchedulingIgnoredDuringExecution:
+                            description: The scheduler will prefer to schedule pods
+                              to nodes that satisfy the anti-affinity expressions
+                              specified by this field, but it may choose a node that
+                              violates one or more of the expressions. The node that
+                              is most preferred is the one with the greatest sum of
+                              weights, i.e. for each node that meets all of the scheduling
+                              requirements (resource request, requiredDuringScheduling
+                              anti-affinity expressions, etc.), compute a sum by iterating
+                              through the elements of this field and adding "weight"
+                              to the sum if the node has pods which matches the corresponding
+                              podAffinityTerm; the node(s) with the highest sum are
+                              the most preferred.
+                            items:
+                              description: The weights of all of the matched WeightedPodAffinityTerm
+                                fields are added per-node to find the most preferred
+                                node(s)
+                              properties:
+                                podAffinityTerm:
+                                  description: Required. A pod affinity term, associated
+                                    with the corresponding weight.
+                                  properties:
+                                    labelSelector:
+                                      description: A label query over a set of resources,
+                                        in this case pods.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: A label selector requirement
+                                              is a selector that contains values,
+                                              a key, and an operator that relates
+                                              the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: operator represents a
+                                                  key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists
+                                                  and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: values is an array of
+                                                  string values. If the operator is
+                                                  In or NotIn, the values array must
+                                                  be non-empty. If the operator is
+                                                  Exists or DoesNotExist, the values
+                                                  array must be empty. This array
+                                                  is replaced during a strategic merge
+                                                  patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: matchLabels is a map of {key,value}
+                                            pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions,
+                                            whose key field is "key", the operator
+                                            is "In", and the values array contains
+                                            only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                    namespaceSelector:
+                                      description: A label query over the set of namespaces
+                                        that the term applies to. The term is applied
+                                        to the union of the namespaces selected by
+                                        this field and the ones listed in the namespaces
+                                        field. null selector and null or empty namespaces
+                                        list means "this pod's namespace". An empty
+                                        selector ({}) matches all namespaces.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: A label selector requirement
+                                              is a selector that contains values,
+                                              a key, and an operator that relates
+                                              the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: operator represents a
+                                                  key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists
+                                                  and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: values is an array of
+                                                  string values. If the operator is
+                                                  In or NotIn, the values array must
+                                                  be non-empty. If the operator is
+                                                  Exists or DoesNotExist, the values
+                                                  array must be empty. This array
+                                                  is replaced during a strategic merge
+                                                  patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: matchLabels is a map of {key,value}
+                                            pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions,
+                                            whose key field is "key", the operator
+                                            is "In", and the values array contains
+                                            only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                    namespaces:
+                                      description: namespaces specifies a static list
+                                        of namespace names that the term applies to.
+                                        The term is applied to the union of the namespaces
+                                        listed in this field and the ones selected
+                                        by namespaceSelector. null or empty namespaces
+                                        list and null namespaceSelector means "this
+                                        pod's namespace".
+                                      items:
+                                        type: string
+                                      type: array
+                                    topologyKey:
+                                      description: This pod should be co-located (affinity)
+                                        or not co-located (anti-affinity) with the
+                                        pods matching the labelSelector in the specified
+                                        namespaces, where co-located is defined as
+                                        running on a node whose value of the label
+                                        with key topologyKey matches that of any node
+                                        on which any of the selected pods is running.
+                                        Empty topologyKey is not allowed.
+                                      type: string
+                                  required:
+                                  - topologyKey
+                                  type: object
+                                weight:
+                                  description: weight associated with matching the
+                                    corresponding podAffinityTerm, in the range 1-100.
+                                  format: int32
+                                  type: integer
+                              required:
+                              - podAffinityTerm
+                              - weight
+                              type: object
+                            type: array
+                          requiredDuringSchedulingIgnoredDuringExecution:
+                            description: If the anti-affinity requirements specified
+                              by this field are not met at scheduling time, the pod
+                              will not be scheduled onto the node. If the anti-affinity
+                              requirements specified by this field cease to be met
+                              at some point during pod execution (e.g. due to a pod
+                              label update), the system may or may not try to eventually
+                              evict the pod from its node. When there are multiple
+                              elements, the lists of nodes corresponding to each podAffinityTerm
+                              are intersected, i.e. all terms must be satisfied.
+                            items:
+                              description: Defines a set of pods (namely those matching
+                                the labelSelector relative to the given namespace(s))
+                                that this pod should be co-located (affinity) or not
+                                co-located (anti-affinity) with, where co-located
+                                is defined as running on a node whose value of the
+                                label with key <topologyKey> matches that of any node
+                                on which a pod of the set of pods is running
+                              properties:
+                                labelSelector:
+                                  description: A label query over a set of resources,
+                                    in this case pods.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
+                                      items:
+                                        description: A label selector requirement
+                                          is a selector that contains values, a key,
+                                          and an operator that relates the key and
+                                          values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that
+                                              the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: operator represents a key's
+                                              relationship to a set of values. Valid
+                                              operators are In, NotIn, Exists and
+                                              DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: values is an array of string
+                                              values. If the operator is In or NotIn,
+                                              the values array must be non-empty.
+                                              If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This
+                                              array is replaced during a strategic
+                                              merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: matchLabels is a map of {key,value}
+                                        pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions,
+                                        whose key field is "key", the operator is
+                                        "In", and the values array contains only "value".
+                                        The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                namespaceSelector:
+                                  description: A label query over the set of namespaces
+                                    that the term applies to. The term is applied
+                                    to the union of the namespaces selected by this
+                                    field and the ones listed in the namespaces field.
+                                    null selector and null or empty namespaces list
+                                    means "this pod's namespace". An empty selector
+                                    ({}) matches all namespaces.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
+                                      items:
+                                        description: A label selector requirement
+                                          is a selector that contains values, a key,
+                                          and an operator that relates the key and
+                                          values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that
+                                              the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: operator represents a key's
+                                              relationship to a set of values. Valid
+                                              operators are In, NotIn, Exists and
+                                              DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: values is an array of string
+                                              values. If the operator is In or NotIn,
+                                              the values array must be non-empty.
+                                              If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This
+                                              array is replaced during a strategic
+                                              merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: matchLabels is a map of {key,value}
+                                        pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions,
+                                        whose key field is "key", the operator is
+                                        "In", and the values array contains only "value".
+                                        The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                namespaces:
+                                  description: namespaces specifies a static list
+                                    of namespace names that the term applies to. The
+                                    term is applied to the union of the namespaces
+                                    listed in this field and the ones selected by
+                                    namespaceSelector. null or empty namespaces list
+                                    and null namespaceSelector means "this pod's namespace".
+                                  items:
+                                    type: string
+                                  type: array
+                                topologyKey:
+                                  description: This pod should be co-located (affinity)
+                                    or not co-located (anti-affinity) with the pods
+                                    matching the labelSelector in the specified namespaces,
+                                    where co-located is defined as running on a node
+                                    whose value of the label with key topologyKey
+                                    matches that of any node on which any of the selected
+                                    pods is running. Empty topologyKey is not allowed.
+                                  type: string
+                              required:
+                              - topologyKey
+                              type: object
+                            type: array
+                        type: object
+                      priorityClassName:
+                        type: string
+                      readinessProbe:
+                        description: ReadinessProbe is a top level field of the values
+                          file
+                        properties:
+                          failureThreshold:
+                            type: integer
+                          initialDelaySeconds:
+                            type: integer
+                          periodSeconds:
+                            type: integer
+                        required:
+                        - failureThreshold
+                        - initialDelaySeconds
+                        - periodSeconds
+                        type: object
+                      replicas:
+                        type: integer
+                      securityContext:
+                        description: SecurityContext holds security configuration
+                          that will be applied to a container. Some fields are present
+                          in both SecurityContext and PodSecurityContext.  When both
+                          are set, the values in SecurityContext take precedence.
+                        properties:
+                          allowPrivilegeEscalation:
+                            description: 'AllowPrivilegeEscalation controls whether
+                              a process can gain more privileges than its parent process.
+                              This bool directly controls if the no_new_privs flag
+                              will be set on the container process. AllowPrivilegeEscalation
+                              is true always when the container is: 1) run as Privileged
+                              2) has CAP_SYS_ADMIN Note that this field cannot be
+                              set when spec.os.name is windows.'
+                            type: boolean
+                          capabilities:
+                            description: The capabilities to add/drop when running
+                              containers. Defaults to the default set of capabilities
+                              granted by the container runtime. Note that this field
+                              cannot be set when spec.os.name is windows.
+                            properties:
+                              add:
+                                description: Added capabilities
+                                items:
+                                  description: Capability represent POSIX capabilities
+                                    type
+                                  type: string
+                                type: array
+                              drop:
+                                description: Removed capabilities
+                                items:
+                                  description: Capability represent POSIX capabilities
+                                    type
+                                  type: string
+                                type: array
+                            type: object
+                          privileged:
+                            description: Run container in privileged mode. Processes
+                              in privileged containers are essentially equivalent
+                              to root on the host. Defaults to false. Note that this
+                              field cannot be set when spec.os.name is windows.
+                            type: boolean
+                          procMount:
+                            description: procMount denotes the type of proc mount
+                              to use for the containers. The default is DefaultProcMount
+                              which uses the container runtime defaults for readonly
+                              paths and masked paths. This requires the ProcMountType
+                              feature flag to be enabled. Note that this field cannot
+                              be set when spec.os.name is windows.
+                            type: string
+                          readOnlyRootFilesystem:
+                            description: Whether this container has a read-only root
+                              filesystem. Default is false. Note that this field cannot
+                              be set when spec.os.name is windows.
+                            type: boolean
+                          runAsGroup:
+                            description: The GID to run the entrypoint of the container
+                              process. Uses runtime default if unset. May also be
+                              set in PodSecurityContext.  If set in both SecurityContext
+                              and PodSecurityContext, the value specified in SecurityContext
+                              takes precedence. Note that this field cannot be set
+                              when spec.os.name is windows.
+                            format: int64
+                            type: integer
+                          runAsNonRoot:
+                            description: Indicates that the container must run as
+                              a non-root user. If true, the Kubelet will validate
+                              the image at runtime to ensure that it does not run
+                              as UID 0 (root) and fail to start the container if it
+                              does. If unset or false, no such validation will be
+                              performed. May also be set in PodSecurityContext.  If
+                              set in both SecurityContext and PodSecurityContext,
+                              the value specified in SecurityContext takes precedence.
+                            type: boolean
+                          runAsUser:
+                            description: The UID to run the entrypoint of the container
+                              process. Defaults to user specified in image metadata
+                              if unspecified. May also be set in PodSecurityContext.  If
+                              set in both SecurityContext and PodSecurityContext,
+                              the value specified in SecurityContext takes precedence.
+                              Note that this field cannot be set when spec.os.name
+                              is windows.
+                            format: int64
+                            type: integer
+                          seLinuxOptions:
+                            description: The SELinux context to be applied to the
+                              container. If unspecified, the container runtime will
+                              allocate a random SELinux context for each container.  May
+                              also be set in PodSecurityContext.  If set in both SecurityContext
+                              and PodSecurityContext, the value specified in SecurityContext
+                              takes precedence. Note that this field cannot be set
+                              when spec.os.name is windows.
+                            properties:
+                              level:
+                                description: Level is SELinux level label that applies
+                                  to the container.
+                                type: string
+                              role:
+                                description: Role is a SELinux role label that applies
+                                  to the container.
+                                type: string
+                              type:
+                                description: Type is a SELinux type label that applies
+                                  to the container.
+                                type: string
+                              user:
+                                description: User is a SELinux user label that applies
+                                  to the container.
+                                type: string
+                            type: object
+                          seccompProfile:
+                            description: The seccomp options to use by this container.
+                              If seccomp options are provided at both the pod & container
+                              level, the container options override the pod options.
+                              Note that this field cannot be set when spec.os.name
+                              is windows.
+                            properties:
+                              localhostProfile:
+                                description: localhostProfile indicates a profile
+                                  defined in a file on the node should be used. The
+                                  profile must be preconfigured on the node to work.
+                                  Must be a descending path, relative to the kubelet's
+                                  configured seccomp profile location. Must only be
+                                  set if type is "Localhost".
+                                type: string
+                              type:
+                                description: "type indicates which kind of seccomp
+                                  profile will be applied. Valid options are: \n Localhost
+                                  - a profile defined in a file on the node should
+                                  be used. RuntimeDefault - the container runtime
+                                  default profile should be used. Unconfined - no
+                                  profile should be applied."
+                                type: string
+                            required:
+                            - type
+                            type: object
+                          windowsOptions:
+                            description: The Windows specific settings applied to
+                              all containers. If unspecified, the options from the
+                              PodSecurityContext will be used. If set in both SecurityContext
+                              and PodSecurityContext, the value specified in SecurityContext
+                              takes precedence. Note that this field cannot be set
+                              when spec.os.name is linux.
+                            properties:
+                              gmsaCredentialSpec:
+                                description: GMSACredentialSpec is where the GMSA
+                                  admission webhook (https://github.com/kubernetes-sigs/windows-gmsa)
+                                  inlines the contents of the GMSA credential spec
+                                  named by the GMSACredentialSpecName field.
+                                type: string
+                              gmsaCredentialSpecName:
+                                description: GMSACredentialSpecName is the name of
+                                  the GMSA credential spec to use.
+                                type: string
+                              hostProcess:
+                                description: HostProcess determines if a container
+                                  should be run as a 'Host Process' container. This
+                                  field is alpha-level and will only be honored by
+                                  components that enable the WindowsHostProcessContainers
+                                  feature flag. Setting this field without the feature
+                                  flag will result in errors when validating the Pod.
+                                  All of a Pod's containers must have the same effective
+                                  HostProcess value (it is not allowed to have a mix
+                                  of HostProcess containers and non-HostProcess containers).  In
+                                  addition, if HostProcess is true then HostNetwork
+                                  must also be set to true.
+                                type: boolean
+                              runAsUserName:
+                                description: The UserName in Windows to run the entrypoint
+                                  of the container process. Defaults to the user specified
+                                  in image metadata if unspecified. May also be set
+                                  in PodSecurityContext. If set in both SecurityContext
+                                  and PodSecurityContext, the value specified in SecurityContext
+                                  takes precedence.
+                                type: string
+                            type: object
+                        type: object
+                      sideCars:
+                        description: SideCars is a field that stores sidecars in the
+                          statefulset
+                        properties:
+                          configWatcher:
+                            properties:
+                              SecurityContext:
+                                description: SecurityContext holds security configuration
+                                  that will be applied to a container. Some fields
+                                  are present in both SecurityContext and PodSecurityContext.  When
+                                  both are set, the values in SecurityContext take
+                                  precedence.
+                                properties:
+                                  allowPrivilegeEscalation:
+                                    description: 'AllowPrivilegeEscalation controls
+                                      whether a process can gain more privileges than
+                                      its parent process. This bool directly controls
+                                      if the no_new_privs flag will be set on the
+                                      container process. AllowPrivilegeEscalation
+                                      is true always when the container is: 1) run
+                                      as Privileged 2) has CAP_SYS_ADMIN Note that
+                                      this field cannot be set when spec.os.name is
+                                      windows.'
+                                    type: boolean
+                                  capabilities:
+                                    description: The capabilities to add/drop when
+                                      running containers. Defaults to the default
+                                      set of capabilities granted by the container
+                                      runtime. Note that this field cannot be set
+                                      when spec.os.name is windows.
+                                    properties:
+                                      add:
+                                        description: Added capabilities
+                                        items:
+                                          description: Capability represent POSIX
+                                            capabilities type
+                                          type: string
+                                        type: array
+                                      drop:
+                                        description: Removed capabilities
+                                        items:
+                                          description: Capability represent POSIX
+                                            capabilities type
+                                          type: string
+                                        type: array
+                                    type: object
+                                  privileged:
+                                    description: Run container in privileged mode.
+                                      Processes in privileged containers are essentially
+                                      equivalent to root on the host. Defaults to
+                                      false. Note that this field cannot be set when
+                                      spec.os.name is windows.
+                                    type: boolean
+                                  procMount:
+                                    description: procMount denotes the type of proc
+                                      mount to use for the containers. The default
+                                      is DefaultProcMount which uses the container
+                                      runtime defaults for readonly paths and masked
+                                      paths. This requires the ProcMountType feature
+                                      flag to be enabled. Note that this field cannot
+                                      be set when spec.os.name is windows.
+                                    type: string
+                                  readOnlyRootFilesystem:
+                                    description: Whether this container has a read-only
+                                      root filesystem. Default is false. Note that
+                                      this field cannot be set when spec.os.name is
+                                      windows.
+                                    type: boolean
+                                  runAsGroup:
+                                    description: The GID to run the entrypoint of
+                                      the container process. Uses runtime default
+                                      if unset. May also be set in PodSecurityContext.  If
+                                      set in both SecurityContext and PodSecurityContext,
+                                      the value specified in SecurityContext takes
+                                      precedence. Note that this field cannot be set
+                                      when spec.os.name is windows.
+                                    format: int64
+                                    type: integer
+                                  runAsNonRoot:
+                                    description: Indicates that the container must
+                                      run as a non-root user. If true, the Kubelet
+                                      will validate the image at runtime to ensure
+                                      that it does not run as UID 0 (root) and fail
+                                      to start the container if it does. If unset
+                                      or false, no such validation will be performed.
+                                      May also be set in PodSecurityContext.  If set
+                                      in both SecurityContext and PodSecurityContext,
+                                      the value specified in SecurityContext takes
+                                      precedence.
+                                    type: boolean
+                                  runAsUser:
+                                    description: The UID to run the entrypoint of
+                                      the container process. Defaults to user specified
+                                      in image metadata if unspecified. May also be
+                                      set in PodSecurityContext.  If set in both SecurityContext
+                                      and PodSecurityContext, the value specified
+                                      in SecurityContext takes precedence. Note that
+                                      this field cannot be set when spec.os.name is
+                                      windows.
+                                    format: int64
+                                    type: integer
+                                  seLinuxOptions:
+                                    description: The SELinux context to be applied
+                                      to the container. If unspecified, the container
+                                      runtime will allocate a random SELinux context
+                                      for each container.  May also be set in PodSecurityContext.  If
+                                      set in both SecurityContext and PodSecurityContext,
+                                      the value specified in SecurityContext takes
+                                      precedence. Note that this field cannot be set
+                                      when spec.os.name is windows.
+                                    properties:
+                                      level:
+                                        description: Level is SELinux level label
+                                          that applies to the container.
+                                        type: string
+                                      role:
+                                        description: Role is a SELinux role label
+                                          that applies to the container.
+                                        type: string
+                                      type:
+                                        description: Type is a SELinux type label
+                                          that applies to the container.
+                                        type: string
+                                      user:
+                                        description: User is a SELinux user label
+                                          that applies to the container.
+                                        type: string
+                                    type: object
+                                  seccompProfile:
+                                    description: The seccomp options to use by this
+                                      container. If seccomp options are provided at
+                                      both the pod & container level, the container
+                                      options override the pod options. Note that
+                                      this field cannot be set when spec.os.name is
+                                      windows.
+                                    properties:
+                                      localhostProfile:
+                                        description: localhostProfile indicates a
+                                          profile defined in a file on the node should
+                                          be used. The profile must be preconfigured
+                                          on the node to work. Must be a descending
+                                          path, relative to the kubelet's configured
+                                          seccomp profile location. Must only be set
+                                          if type is "Localhost".
+                                        type: string
+                                      type:
+                                        description: "type indicates which kind of
+                                          seccomp profile will be applied. Valid options
+                                          are: \n Localhost - a profile defined in
+                                          a file on the node should be used. RuntimeDefault
+                                          - the container runtime default profile
+                                          should be used. Unconfined - no profile
+                                          should be applied."
+                                        type: string
+                                    required:
+                                    - type
+                                    type: object
+                                  windowsOptions:
+                                    description: The Windows specific settings applied
+                                      to all containers. If unspecified, the options
+                                      from the PodSecurityContext will be used. If
+                                      set in both SecurityContext and PodSecurityContext,
+                                      the value specified in SecurityContext takes
+                                      precedence. Note that this field cannot be set
+                                      when spec.os.name is linux.
+                                    properties:
+                                      gmsaCredentialSpec:
+                                        description: GMSACredentialSpec is where the
+                                          GMSA admission webhook (https://github.com/kubernetes-sigs/windows-gmsa)
+                                          inlines the contents of the GMSA credential
+                                          spec named by the GMSACredentialSpecName
+                                          field.
+                                        type: string
+                                      gmsaCredentialSpecName:
+                                        description: GMSACredentialSpecName is the
+                                          name of the GMSA credential spec to use.
+                                        type: string
+                                      hostProcess:
+                                        description: HostProcess determines if a container
+                                          should be run as a 'Host Process' container.
+                                          This field is alpha-level and will only
+                                          be honored by components that enable the
+                                          WindowsHostProcessContainers feature flag.
+                                          Setting this field without the feature flag
+                                          will result in errors when validating the
+                                          Pod. All of a Pod's containers must have
+                                          the same effective HostProcess value (it
+                                          is not allowed to have a mix of HostProcess
+                                          containers and non-HostProcess containers).  In
+                                          addition, if HostProcess is true then HostNetwork
+                                          must also be set to true.
+                                        type: boolean
+                                      runAsUserName:
+                                        description: The UserName in Windows to run
+                                          the entrypoint of the container process.
+                                          Defaults to the user specified in image
+                                          metadata if unspecified. May also be set
+                                          in PodSecurityContext. If set in both SecurityContext
+                                          and PodSecurityContext, the value specified
+                                          in SecurityContext takes precedence.
+                                        type: string
+                                    type: object
+                                type: object
+                              enabled:
+                                type: boolean
+                              extraVolumeMounts:
+                                type: string
+                              resources:
+                                description: ResourceRequirements describes the compute
+                                  resource requirements.
+                                properties:
+                                  claims:
+                                    description: "Claims lists the names of resources,
+                                      defined in spec.resourceClaims, that are used
+                                      by this container. \n This is an alpha field
+                                      and requires enabling the DynamicResourceAllocation
+                                      feature gate. \n This field is immutable."
+                                    items:
+                                      description: ResourceClaim references one entry
+                                        in PodSpec.ResourceClaims.
+                                      properties:
+                                        name:
+                                          description: Name must match the name of
+                                            one entry in pod.spec.resourceClaims of
+                                            the Pod where this field is used. It makes
+                                            that resource available inside a container.
+                                          type: string
+                                      required:
+                                      - name
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-map-keys:
+                                    - name
+                                    x-kubernetes-list-type: map
+                                  limits:
+                                    additionalProperties:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                      x-kubernetes-int-or-string: true
+                                    description: 'Limits describes the maximum amount
+                                      of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                    type: object
+                                  requests:
+                                    additionalProperties:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                      x-kubernetes-int-or-string: true
+                                    description: 'Requests describes the minimum amount
+                                      of compute resources required. If Requests is
+                                      omitted for a container, it defaults to Limits
+                                      if that is explicitly specified, otherwise to
+                                      an implementation-defined value. More info:
+                                      https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                    type: object
+                                type: object
+                            type: object
+                          rpkStatus:
+                            description: SideCarObj represents generic sidecar object.
+                              This is a placeholder for now as it may each sidecar
+                              entry may require more specific impl.
+                            properties:
+                              SecurityContext:
+                                description: SecurityContext holds security configuration
+                                  that will be applied to a container. Some fields
+                                  are present in both SecurityContext and PodSecurityContext.  When
+                                  both are set, the values in SecurityContext take
+                                  precedence.
+                                properties:
+                                  allowPrivilegeEscalation:
+                                    description: 'AllowPrivilegeEscalation controls
+                                      whether a process can gain more privileges than
+                                      its parent process. This bool directly controls
+                                      if the no_new_privs flag will be set on the
+                                      container process. AllowPrivilegeEscalation
+                                      is true always when the container is: 1) run
+                                      as Privileged 2) has CAP_SYS_ADMIN Note that
+                                      this field cannot be set when spec.os.name is
+                                      windows.'
+                                    type: boolean
+                                  capabilities:
+                                    description: The capabilities to add/drop when
+                                      running containers. Defaults to the default
+                                      set of capabilities granted by the container
+                                      runtime. Note that this field cannot be set
+                                      when spec.os.name is windows.
+                                    properties:
+                                      add:
+                                        description: Added capabilities
+                                        items:
+                                          description: Capability represent POSIX
+                                            capabilities type
+                                          type: string
+                                        type: array
+                                      drop:
+                                        description: Removed capabilities
+                                        items:
+                                          description: Capability represent POSIX
+                                            capabilities type
+                                          type: string
+                                        type: array
+                                    type: object
+                                  privileged:
+                                    description: Run container in privileged mode.
+                                      Processes in privileged containers are essentially
+                                      equivalent to root on the host. Defaults to
+                                      false. Note that this field cannot be set when
+                                      spec.os.name is windows.
+                                    type: boolean
+                                  procMount:
+                                    description: procMount denotes the type of proc
+                                      mount to use for the containers. The default
+                                      is DefaultProcMount which uses the container
+                                      runtime defaults for readonly paths and masked
+                                      paths. This requires the ProcMountType feature
+                                      flag to be enabled. Note that this field cannot
+                                      be set when spec.os.name is windows.
+                                    type: string
+                                  readOnlyRootFilesystem:
+                                    description: Whether this container has a read-only
+                                      root filesystem. Default is false. Note that
+                                      this field cannot be set when spec.os.name is
+                                      windows.
+                                    type: boolean
+                                  runAsGroup:
+                                    description: The GID to run the entrypoint of
+                                      the container process. Uses runtime default
+                                      if unset. May also be set in PodSecurityContext.  If
+                                      set in both SecurityContext and PodSecurityContext,
+                                      the value specified in SecurityContext takes
+                                      precedence. Note that this field cannot be set
+                                      when spec.os.name is windows.
+                                    format: int64
+                                    type: integer
+                                  runAsNonRoot:
+                                    description: Indicates that the container must
+                                      run as a non-root user. If true, the Kubelet
+                                      will validate the image at runtime to ensure
+                                      that it does not run as UID 0 (root) and fail
+                                      to start the container if it does. If unset
+                                      or false, no such validation will be performed.
+                                      May also be set in PodSecurityContext.  If set
+                                      in both SecurityContext and PodSecurityContext,
+                                      the value specified in SecurityContext takes
+                                      precedence.
+                                    type: boolean
+                                  runAsUser:
+                                    description: The UID to run the entrypoint of
+                                      the container process. Defaults to user specified
+                                      in image metadata if unspecified. May also be
+                                      set in PodSecurityContext.  If set in both SecurityContext
+                                      and PodSecurityContext, the value specified
+                                      in SecurityContext takes precedence. Note that
+                                      this field cannot be set when spec.os.name is
+                                      windows.
+                                    format: int64
+                                    type: integer
+                                  seLinuxOptions:
+                                    description: The SELinux context to be applied
+                                      to the container. If unspecified, the container
+                                      runtime will allocate a random SELinux context
+                                      for each container.  May also be set in PodSecurityContext.  If
+                                      set in both SecurityContext and PodSecurityContext,
+                                      the value specified in SecurityContext takes
+                                      precedence. Note that this field cannot be set
+                                      when spec.os.name is windows.
+                                    properties:
+                                      level:
+                                        description: Level is SELinux level label
+                                          that applies to the container.
+                                        type: string
+                                      role:
+                                        description: Role is a SELinux role label
+                                          that applies to the container.
+                                        type: string
+                                      type:
+                                        description: Type is a SELinux type label
+                                          that applies to the container.
+                                        type: string
+                                      user:
+                                        description: User is a SELinux user label
+                                          that applies to the container.
+                                        type: string
+                                    type: object
+                                  seccompProfile:
+                                    description: The seccomp options to use by this
+                                      container. If seccomp options are provided at
+                                      both the pod & container level, the container
+                                      options override the pod options. Note that
+                                      this field cannot be set when spec.os.name is
+                                      windows.
+                                    properties:
+                                      localhostProfile:
+                                        description: localhostProfile indicates a
+                                          profile defined in a file on the node should
+                                          be used. The profile must be preconfigured
+                                          on the node to work. Must be a descending
+                                          path, relative to the kubelet's configured
+                                          seccomp profile location. Must only be set
+                                          if type is "Localhost".
+                                        type: string
+                                      type:
+                                        description: "type indicates which kind of
+                                          seccomp profile will be applied. Valid options
+                                          are: \n Localhost - a profile defined in
+                                          a file on the node should be used. RuntimeDefault
+                                          - the container runtime default profile
+                                          should be used. Unconfined - no profile
+                                          should be applied."
+                                        type: string
+                                    required:
+                                    - type
+                                    type: object
+                                  windowsOptions:
+                                    description: The Windows specific settings applied
+                                      to all containers. If unspecified, the options
+                                      from the PodSecurityContext will be used. If
+                                      set in both SecurityContext and PodSecurityContext,
+                                      the value specified in SecurityContext takes
+                                      precedence. Note that this field cannot be set
+                                      when spec.os.name is linux.
+                                    properties:
+                                      gmsaCredentialSpec:
+                                        description: GMSACredentialSpec is where the
+                                          GMSA admission webhook (https://github.com/kubernetes-sigs/windows-gmsa)
+                                          inlines the contents of the GMSA credential
+                                          spec named by the GMSACredentialSpecName
+                                          field.
+                                        type: string
+                                      gmsaCredentialSpecName:
+                                        description: GMSACredentialSpecName is the
+                                          name of the GMSA credential spec to use.
+                                        type: string
+                                      hostProcess:
+                                        description: HostProcess determines if a container
+                                          should be run as a 'Host Process' container.
+                                          This field is alpha-level and will only
+                                          be honored by components that enable the
+                                          WindowsHostProcessContainers feature flag.
+                                          Setting this field without the feature flag
+                                          will result in errors when validating the
+                                          Pod. All of a Pod's containers must have
+                                          the same effective HostProcess value (it
+                                          is not allowed to have a mix of HostProcess
+                                          containers and non-HostProcess containers).  In
+                                          addition, if HostProcess is true then HostNetwork
+                                          must also be set to true.
+                                        type: boolean
+                                      runAsUserName:
+                                        description: The UserName in Windows to run
+                                          the entrypoint of the container process.
+                                          Defaults to the user specified in image
+                                          metadata if unspecified. May also be set
+                                          in PodSecurityContext. If set in both SecurityContext
+                                          and PodSecurityContext, the value specified
+                                          in SecurityContext takes precedence.
+                                        type: string
+                                    type: object
+                                type: object
+                              enabled:
+                                type: boolean
+                              resources:
+                                description: ResourceRequirements describes the compute
+                                  resource requirements.
+                                properties:
+                                  claims:
+                                    description: "Claims lists the names of resources,
+                                      defined in spec.resourceClaims, that are used
+                                      by this container. \n This is an alpha field
+                                      and requires enabling the DynamicResourceAllocation
+                                      feature gate. \n This field is immutable."
+                                    items:
+                                      description: ResourceClaim references one entry
+                                        in PodSpec.ResourceClaims.
+                                      properties:
+                                        name:
+                                          description: Name must match the name of
+                                            one entry in pod.spec.resourceClaims of
+                                            the Pod where this field is used. It makes
+                                            that resource available inside a container.
+                                          type: string
+                                      required:
+                                      - name
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-map-keys:
+                                    - name
+                                    x-kubernetes-list-type: map
+                                  limits:
+                                    additionalProperties:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                      x-kubernetes-int-or-string: true
+                                    description: 'Limits describes the maximum amount
+                                      of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                    type: object
+                                  requests:
+                                    additionalProperties:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                      x-kubernetes-int-or-string: true
+                                    description: 'Requests describes the minimum amount
+                                      of compute resources required. If Requests is
+                                      omitted for a container, it defaults to Limits
+                                      if that is explicitly specified, otherwise to
+                                      an implementation-defined value. More info:
+                                      https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                    type: object
+                                type: object
+                            type: object
+                        type: object
+                      skipChown:
+                        type: boolean
+                      startupProbe:
+                        description: StartupProbe is a top level field of the values
+                          file
+                        properties:
+                          failureThreshold:
+                            type: integer
+                          initialDelaySeconds:
+                            type: integer
+                          periodSeconds:
+                            type: integer
+                        required:
+                        - failureThreshold
+                        - initialDelaySeconds
+                        - periodSeconds
+                        type: object
+                      terminationGracePeriodSeconds:
+                        type: integer
+                      tolerations:
+                        items:
+                          description: The pod this Toleration is attached to tolerates
+                            any taint that matches the triple <key,value,effect> using
+                            the matching operator <operator>.
+                          properties:
+                            effect:
+                              description: Effect indicates the taint effect to match.
+                                Empty means match all taint effects. When specified,
+                                allowed values are NoSchedule, PreferNoSchedule and
+                                NoExecute.
+                              type: string
+                            key:
+                              description: Key is the taint key that the toleration
+                                applies to. Empty means match all taint keys. If the
+                                key is empty, operator must be Exists; this combination
+                                means to match all values and all keys.
+                              type: string
+                            operator:
+                              description: Operator represents a key's relationship
+                                to the value. Valid operators are Exists and Equal.
+                                Defaults to Equal. Exists is equivalent to wildcard
+                                for value, so that a pod can tolerate all taints of
+                                a particular category.
+                              type: string
+                            tolerationSeconds:
+                              description: TolerationSeconds represents the period
+                                of time the toleration (which must be of effect NoExecute,
+                                otherwise this field is ignored) tolerates the taint.
+                                By default, it is not set, which means tolerate the
+                                taint forever (do not evict). Zero and negative values
+                                will be treated as 0 (evict immediately) by the system.
+                              format: int64
+                              type: integer
+                            value:
+                              description: Value is the taint value the toleration
+                                matches to. If the operator is Exists, the value should
+                                be empty, otherwise just a regular string.
+                              type: string
+                          type: object
+                        type: array
+                      topologySpreadConstraints:
+                        description: TopologySpreadConstraints is a top level field
+                          of the values file
+                        properties:
+                          maxSkew:
+                            type: integer
+                          topologyKey:
+                            type: string
+                          whenUnsatisfiable:
+                            type: string
+                        required:
+                        - maxSkew
+                        - topologyKey
+                        - whenUnsatisfiable
+                        type: object
+                      updateStrategy:
+                        description: UpdateStrategy is a top level field of the values
+                          file
+                        properties:
+                          type:
+                            type: string
+                        required:
+                        - type
+                        type: object
+                    type: object
+                  storage:
+                    description: Storage is a top level field of the values file
+                    properties:
+                      hostPath:
+                        type: string
+                      persistentVolume:
+                        description: PersistentVolume is a top level field of the
+                          values file
+                        properties:
+                          annotations:
+                            additionalProperties:
+                              type: string
+                            type: object
+                          enabled:
+                            type: boolean
+                          labels:
+                            additionalProperties:
+                              type: string
+                            type: object
+                          size:
+                            type: string
+                          storageClass:
+                            type: string
+                        required:
+                        - enabled
+                        type: object
+                      tieredConfig:
+                        description: TieredConfig is a top level field of the values
+                          file
+                        properties:
+                          cloud_storage_api_endpoint:
+                            type: string
+                          cloud_storage_api_endpoint_port:
+                            type: integer
+                          cloud_storage_bucket:
+                            type: string
+                          cloud_storage_cache_check_interval:
+                            type: integer
+                          cloud_storage_cache_directory:
+                            type: string
+                          cloud_storage_cache_size:
+                            type: integer
+                          cloud_storage_credentials_source:
+                            type: string
+                          cloud_storage_disable_tls:
+                            type: boolean
+                          cloud_storage_enable_remote_read:
+                            type: boolean
+                          cloud_storage_enable_remote_write:
+                            type: boolean
+                          cloud_storage_initial_backoff_ms:
+                            type: integer
+                          cloud_storage_manifest_upload_timeout_ms:
+                            type: integer
+                          cloud_storage_max_connection_idle_time_ms:
+                            type: integer
+                          cloud_storage_max_connections:
+                            type: integer
+                          cloud_storage_reconciliation_interval_ms:
+                            type: integer
+                          cloud_storage_region:
+                            type: string
+                          cloud_storage_segment_max_upload_interval_sec:
+                            type: integer
+                          cloud_storage_segment_upload_timeout_ms:
+                            type: integer
+                          cloud_storage_trust_file:
+                            type: string
+                          cloud_storage_upload_ctrl_d_coeff:
+                            type: integer
+                          cloud_storage_upload_ctrl_max_shares:
+                            type: integer
+                          cloud_storage_upload_ctrl_min_shares:
+                            type: integer
+                          cloud_storage_upload_ctrl_p_coeff:
+                            type: integer
+                          cloud_storage_upload_ctrl_update_interval_ms:
+                            type: integer
+                        required:
+                        - cloud_storage_bucket
+                        - cloud_storage_region
+                        type: object
+                      tieredStorageHostPath:
+                        type: string
+                      tieredStoragePersistentVolume:
+                        description: TieredStoragePersistentVolume is a top level
+                          field of the values file
+                        properties:
+                          annotations:
+                            additionalProperties:
+                              type: string
+                            type: object
+                          enabled:
+                            type: boolean
+                          labels:
+                            additionalProperties:
+                              type: string
+                            type: object
+                          storageClass:
+                            type: string
+                        required:
+                        - annotations
+                        - enabled
+                        - labels
+                        - storageClass
+                        type: object
+                    type: object
+                  tls:
+                    description: TLS is a top level field of the values file
+                    properties:
+                      certs:
+                        additionalProperties:
+                          properties:
+                            caEnabled:
+                              type: boolean
+                            duration:
+                              description: A Duration represents the elapsed time
+                                between two instants as an int64 nanosecond count.
+                                The representation limits the largest representable
+                                duration to approximately 290 years.
+                              format: int64
+                              type: integer
+                            issuerRef:
+                              properties:
+                                kind:
+                                  type: string
+                                name:
+                                  type: string
+                              required:
+                              - kind
+                              - name
+                              type: object
+                            secretRef:
+                              properties:
+                                name:
+                                  type: string
+                              required:
+                              - name
+                              type: object
+                          required:
+                          - caEnabled
+                          type: object
+                        type: object
+                      enabled:
+                        type: boolean
+                    type: object
+                  tolerations:
+                    description: Tolerations is the override to give your redpanda
+                      release
+                    items:
+                      description: The pod this Toleration is attached to tolerates
+                        any taint that matches the triple <key,value,effect> using
+                        the matching operator <operator>.
+                      properties:
+                        effect:
+                          description: Effect indicates the taint effect to match.
+                            Empty means match all taint effects. When specified, allowed
+                            values are NoSchedule, PreferNoSchedule and NoExecute.
+                          type: string
+                        key:
+                          description: Key is the taint key that the toleration applies
+                            to. Empty means match all taint keys. If the key is empty,
+                            operator must be Exists; this combination means to match
+                            all values and all keys.
+                          type: string
+                        operator:
+                          description: Operator represents a key's relationship to
+                            the value. Valid operators are Exists and Equal. Defaults
+                            to Equal. Exists is equivalent to wildcard for value,
+                            so that a pod can tolerate all taints of a particular
+                            category.
+                          type: string
+                        tolerationSeconds:
+                          description: TolerationSeconds represents the period of
+                            time the toleration (which must be of effect NoExecute,
+                            otherwise this field is ignored) tolerates the taint.
+                            By default, it is not set, which means tolerate the taint
+                            forever (do not evict). Zero and negative values will
+                            be treated as 0 (evict immediately) by the system.
+                          format: int64
+                          type: integer
+                        value:
+                          description: Value is the taint value the toleration matches
+                            to. If the operator is Exists, the value should be empty,
+                            otherwise just a regular string.
+                          type: string
+                      type: object
+                    type: array
+                  tuning:
+                    description: Tuning is a top level field of the values file
+                    properties:
+                      ballast_file_path:
+                        type: string
+                      ballast_file_size:
+                        type: string
+                      extraVolumeMounts:
+                        type: string
+                      resources:
+                        description: ResourceRequirements describes the compute resource
+                          requirements.
+                        properties:
+                          claims:
+                            description: "Claims lists the names of resources, defined
+                              in spec.resourceClaims, that are used by this container.
+                              \n This is an alpha field and requires enabling the
+                              DynamicResourceAllocation feature gate. \n This field
+                              is immutable."
+                            items:
+                              description: ResourceClaim references one entry in PodSpec.ResourceClaims.
+                              properties:
+                                name:
+                                  description: Name must match the name of one entry
+                                    in pod.spec.resourceClaims of the Pod where this
+                                    field is used. It makes that resource available
+                                    inside a container.
+                                  type: string
+                              required:
+                              - name
+                              type: object
+                            type: array
+                            x-kubernetes-list-map-keys:
+                            - name
+                            x-kubernetes-list-type: map
+                          limits:
+                            additionalProperties:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            description: 'Limits describes the maximum amount of compute
+                              resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                            type: object
+                          requests:
+                            additionalProperties:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            description: 'Requests describes the minimum amount of
+                              compute resources required. If Requests is omitted for
+                              a container, it defaults to Limits if that is explicitly
+                              specified, otherwise to an implementation-defined value.
+                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                            type: object
+                        type: object
+                      tune_aio_events:
+                        type: boolean
+                      tune_ballast_file:
+                        type: boolean
+                      tune_clocksource:
+                        type: boolean
+                      well_known_io:
+                        type: string
+                    type: object
+                type: object
+            type: object
+          status:
+            description: RedpandaStatus defines the observed state of Redpanda
+            properties:
+              conditions:
+                description: Conditions holds the conditions for the Redpanda.
+                items:
+                  description: "Condition contains details for one aspect of the current
+                    state of this API Resource. --- This struct is intended for direct
+                    use as an array at the field path .status.conditions.  For example,
+                    \n \ttype FooStatus struct{ \t    // Represents the observations
+                    of a foo's current state. \t    // Known .status.conditions.type
+                    are: \"Available\", \"Progressing\", and \"Degraded\" \t    //
+                    +patchMergeKey=type \t    // +patchStrategy=merge \t    // +listType=map
+                    \t    // +listMapKey=type \t    Conditions []metav1.Condition
+                    `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\"
+                    protobuf:\"bytes,1,rep,name=conditions\"` \n \t    // other fields
+                    \t}"
+                  properties:
+                    lastTransitionTime:
+                      description: lastTransitionTime is the last time the condition
+                        transitioned from one status to another. This should be when
+                        the underlying condition changed.  If that is not known, then
+                        using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: message is a human readable message indicating
+                        details about the transition. This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: observedGeneration represents the .metadata.generation
+                        that the condition was set based upon. For instance, if .metadata.generation
+                        is currently 12, but the .status.conditions[x].observedGeneration
+                        is 9, the condition is out of date with respect to the current
+                        state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: reason contains a programmatic identifier indicating
+                        the reason for the condition's last transition. Producers
+                        of specific condition types may define expected values and
+                        meanings for this field, and whether the values are considered
+                        a guaranteed API. The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        --- Many .condition.type values are consistent across resources
+                        like Available, but because arbitrary conditions can be useful
+                        (see .node.status.conditions), the ability to deconflict is
+                        important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              failures:
+                description: Failures is the reconciliation failure count against
+                  the latest desired state. It is reset after a successful reconciliation.
+                format: int64
+                type: integer
+              helmRelease:
+                type: string
+              helmReleaseReady:
+                type: boolean
+              helmRepository:
+                type: string
+              helmRepositoryReady:
+                type: boolean
+              installFailures:
+                format: int64
+                type: integer
+              lastAppliedRevision:
+                description: LastAppliedRevision is the revision of the last successfully
+                  applied source.
+                type: string
+              lastAttemptedRevision:
+                description: LastAttemptedRevision is the revision of the last reconciliation
+                  attempt.
+                type: string
+              lastHandledReconcileAt:
+                description: LastHandledReconcileAt holds the value of the most recent
+                  reconcile request value, so a change of the annotation value can
+                  be detected.
+                type: string
+              observedGeneration:
+                description: ObservedGeneration is the last observed generation.
+                format: int64
+                type: integer
+              upgradeFailures:
+                format: int64
+                type: integer
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.4.1
+  creationTimestamp: null
+  name: topics.cluster.redpanda.com
+spec:
+  group: cluster.redpanda.com
+  names:
+    kind: Topic
+    listKind: TopicList
+    plural: topics
+    singular: topic
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: Topic is the Schema for the topics API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: TopicSpec defines the desired state of Topic
+            properties:
+              additionalConfig:
+                additionalProperties:
+                  type: string
+                description: 'AdditionalConfig is free form map of any configuration
+                  option that topic can have. Examples: cleanup.policy=compact redpanda.remote.write=true
+                  redpanda.remote.read=true redpanda.remote.recovery=true redpanda.remote.delete=true'
+                type: object
+              interval:
+                default: 3s
+                description: SynchronizationInterval when the topic controller will
+                  schedule next reconciliation Default is 3 seconds
+                format: duration
+                type: string
+              kafkaApiSpec:
+                description: KafkaAPISpec is client configuration for connecting to
+                  Redpanda brokers
+                properties:
+                  brokers:
+                    items:
+                      type: string
+                    type: array
+                  sasl:
+                    description: KafkaSASL to connect to Kafka using SASL credentials
+                    properties:
+                      awsMskIam:
+                        description: 'KafkaSASLAWSMskIam is the config for AWS IAM
+                          SASL mechanism, see: https://docs.aws.amazon.com/msk/latest/developerguide/iam-access-control.html'
+                        properties:
+                          accessKey:
+                            type: string
+                          secretKeySecretRef:
+                            description: SecretKeyRef contains enough information
+                              to inspect or modify the referred Secret data REF https://pkg.go.dev/k8s.io/api/core/v1#ObjectReference
+                            properties:
+                              key:
+                                description: Key in Secret data to get value from
+                                type: string
+                              name:
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                type: string
+                            required:
+                            - name
+                            type: object
+                          sessionTokenSecretRef:
+                            description: 'SessionToken, if non-empty, is a session
+                              / security token to use for authentication. See: https://docs.aws.amazon.com/STS/latest/APIReference/welcome.html'
+                            properties:
+                              key:
+                                description: Key in Secret data to get value from
+                                type: string
+                              name:
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                type: string
+                            required:
+                            - name
+                            type: object
+                          userAgent:
+                            description: "UserAgent is the user agent to for the client
+                              to use when connecting to Kafka, overriding the default
+                              \"franz-go/<runtime.Version()>/<hostname>\". \n Setting
+                              a UserAgent allows authorizing based on the aws:UserAgent
+                              condition key; see the following link for more details:
+                              https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_condition-keys.html#condition-keys-useragent"
+                            type: string
+                        required:
+                        - accessKey
+                        - secretKeySecretRef
+                        - sessionTokenSecretRef
+                        - userAgent
+                        type: object
+                      gssapi:
+                        description: KafkaSASLGSSAPI represents the Kafka Kerberos
+                          config.
+                        properties:
+                          authType:
+                            type: string
+                          enableFast:
+                            description: EnableFAST enables FAST, which is a pre-authentication
+                              framework for Kerberos. It includes a mechanism for
+                              tunneling pre-authentication exchanges using armored
+                              KDC messages. FAST provides increased resistance to
+                              passive password guessing attacks.
+                            type: boolean
+                          kerberosConfigPath:
+                            type: string
+                          keyTabPath:
+                            type: string
+                          passwordSecretRef:
+                            description: SecretKeyRef contains enough information
+                              to inspect or modify the referred Secret data REF https://pkg.go.dev/k8s.io/api/core/v1#ObjectReference
+                            properties:
+                              key:
+                                description: Key in Secret data to get value from
+                                type: string
+                              name:
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                type: string
+                            required:
+                            - name
+                            type: object
+                          realm:
+                            type: string
+                          serviceName:
+                            type: string
+                          username:
+                            type: string
+                        required:
+                        - authType
+                        - enableFast
+                        - kerberosConfigPath
+                        - keyTabPath
+                        - passwordSecretRef
+                        - realm
+                        - serviceName
+                        - username
+                        type: object
+                      mechanism:
+                        type: string
+                      oauth:
+                        description: KafkaSASLOAuthBearer is the config struct for
+                          the SASL OAuthBearer mechanism
+                        properties:
+                          tokenSecretRef:
+                            description: SecretKeyRef contains enough information
+                              to inspect or modify the referred Secret data REF https://pkg.go.dev/k8s.io/api/core/v1#ObjectReference
+                            properties:
+                              key:
+                                description: Key in Secret data to get value from
+                                type: string
+                              name:
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                type: string
+                            required:
+                            - name
+                            type: object
+                        required:
+                        - tokenSecretRef
+                        type: object
+                      passwordSecretRef:
+                        description: SecretKeyRef contains enough information to inspect
+                          or modify the referred Secret data REF https://pkg.go.dev/k8s.io/api/core/v1#ObjectReference
+                        properties:
+                          key:
+                            description: Key in Secret data to get value from
+                            type: string
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                            type: string
+                        required:
+                        - name
+                        type: object
+                      username:
+                        type: string
+                    required:
+                    - mechanism
+                    type: object
+                  tls:
+                    description: KafkaTLS to connect to Kafka via TLS
+                    properties:
+                      caCertSecretRef:
+                        description: CaCert is the reference for certificate authority
+                          used to establish TLS connection to Redpanda
+                        properties:
+                          key:
+                            description: Key in Secret data to get value from
+                            type: string
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                            type: string
+                        required:
+                        - name
+                        type: object
+                      certSecretRef:
+                        description: Cert is the reference for client public certificate
+                          to establish mTLS connection to Redpanda
+                        properties:
+                          key:
+                            description: Key in Secret data to get value from
+                            type: string
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                            type: string
+                        required:
+                        - name
+                        type: object
+                      insecureSkipTlsVerify:
+                        description: InsecureSkipTLSVerify can skip verifying Redpanda
+                          self-signed certificate when establish TLS connection to
+                          Redpanda
+                        type: boolean
+                      keySecretRef:
+                        description: Key is the reference for client private certificate
+                          to establish mTLS connection to Redpanda
+                        properties:
+                          key:
+                            description: Key in Secret data to get value from
+                            type: string
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                            type: string
+                        required:
+                        - name
+                        type: object
+                    type: object
+                required:
+                - brokers
+                type: object
+              metricsNamespace:
+                description: MetricsNamespace can be used to overwrite fully-qualified
+                  name of the Metric. That should be easier to identify if multiple
+                  operator runs inside the same Kubernetes cluster. By default, it
+                  is set to `redpanda-operator`.
+                type: string
+              overwriteTopicName:
+                description: OverwriteTopicName will change the topic name from the
+                  `metadata.name` to `OverwriteTopicName`
+                type: string
+              partitions:
+                description: Partitions is the number topic shards that is distributed
+                  across the nodes in a cluster. This cannot be decreased after topic
+                  creation. It can be increased after topic creation, but it is important
+                  to understand the consequences that has, especially for topics with
+                  semantic partitioning. When absent this will default to the Redpanda
+                  cluster configuration `default_topic_partitions`. https://docs.redpanda.com/docs/reference/cluster-properties/#default_topic_partitions
+                  https://docs.redpanda.com/docs/get-started/architecture/#partitions
+                type: integer
+              replicationFactor:
+                description: ReplicationFactor is the number of replicas the topic
+                  should have. Must be odd value. When absent this will default to
+                  the Redpanda cluster configuration `default_topic_replications`.
+                  https://docs.redpanda.com/docs/reference/cluster-properties/#default_topic_replications
+                type: integer
+            type: object
+          status:
+            description: TopicStatus defines the observed state of Topic
+            properties:
+              conditions:
+                description: Conditions holds the conditions for the Topic.
+                items:
+                  description: "Condition contains details for one aspect of the current
+                    state of this API Resource. --- This struct is intended for direct
+                    use as an array at the field path .status.conditions.  For example,
+                    \n \ttype FooStatus struct{ \t    // Represents the observations
+                    of a foo's current state. \t    // Known .status.conditions.type
+                    are: \"Available\", \"Progressing\", and \"Degraded\" \t    //
+                    +patchMergeKey=type \t    // +patchStrategy=merge \t    // +listType=map
+                    \t    // +listMapKey=type \t    Conditions []metav1.Condition
+                    `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\"
+                    protobuf:\"bytes,1,rep,name=conditions\"` \n \t    // other fields
+                    \t}"
+                  properties:
+                    lastTransitionTime:
+                      description: lastTransitionTime is the last time the condition
+                        transitioned from one status to another. This should be when
+                        the underlying condition changed.  If that is not known, then
+                        using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: message is a human readable message indicating
+                        details about the transition. This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: observedGeneration represents the .metadata.generation
+                        that the condition was set based upon. For instance, if .metadata.generation
+                        is currently 12, but the .status.conditions[x].observedGeneration
+                        is 9, the condition is out of date with respect to the current
+                        state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: reason contains a programmatic identifier indicating
+                        the reason for the condition's last transition. Producers
+                        of specific condition types may define expected values and
+                        meanings for this field, and whether the values are considered
+                        a guaranteed API. The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        --- Many .condition.type values are consistent across resources
+                        like Available, but because arbitrary conditions can be useful
+                        (see .node.status.conditions), the ability to deconflict is
+                        important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              observedGeneration:
+                description: ObservedGeneration is the last observed generation of
+                  the Topic.
+                format: int64
+                type: integer
+              topicConfiguration:
+                description: TopicConfiguration is the last snapshot of the topic
+                  configuration during successful reconciliation.
+                items:
+                  description: Configuration was copied from https://github.com/twmb/franz-go/blob/01651affd204d4a3577a341e748c5d09b52587f8/pkg/kmsg/generated.go#L24593-L24634
+                  properties:
+                    configSynonyms:
+                      description: ConfigSynonyms contains fallback key/value pairs
+                        for this config entry, in order of preference. That is, if
+                        a config entry is both dynamically configured and has a default,
+                        the top level return will be the dynamic configuration, while
+                        its "synonym" will be the default.
+                      items:
+                        description: ConfigSynonyms was copied from https://github.com/twmb/franz-go/blob/01651affd204d4a3577a341e748c5d09b52587f8/pkg/kmsg/generated.go#L24569-L24578
+                        properties:
+                          name:
+                            type: string
+                          source:
+                            type: string
+                          unknownTags:
+                            additionalProperties:
+                              type: string
+                            description: UnknownTags are tags Kafka sent that we do
+                              not know the purpose of.
+                            type: object
+                          value:
+                            type: string
+                        required:
+                        - name
+                        - source
+                        type: object
+                      type: array
+                    configType:
+                      description: ConfigType specifies the configuration data type.
+                      type: string
+                    documentation:
+                      description: Documentation is optional documentation for the
+                        config entry.
+                      type: string
+                    isDefault:
+                      description: IsDefault is whether this is a default config option.
+                        This has been replaced in favor of Source.
+                      type: boolean
+                    isSensitive:
+                      description: IsSensitive signifies whether this is a sensitive
+                        config key, which is either a password or an unknown type.
+                      type: boolean
+                    name:
+                      description: Name is a key this entry corresponds to (e.g. segment.bytes).
+                      type: string
+                    readOnly:
+                      description: "ReadOnly signifies whether this is not a dynamic
+                        config option. \n Note that this field is not always correct,
+                        and you may need to check whether the Source is any dynamic
+                        enum. See franz-go#91 for more details."
+                      type: boolean
+                    source:
+                      description: "Source is where this config entry is from. \n
+                        This field has a default of -1."
+                      type: string
+                    unknownTags:
+                      additionalProperties:
+                        type: string
+                      description: UnknownTags are tags Kafka sent that we do not
+                        know the purpose of.
+                      type: object
+                    value:
+                      description: Value is the value for this config key. If the
+                        key is sensitive, the value will be null.
+                      type: string
+                  required:
+                  - configType
+                  - isDefault
+                  - isSensitive
+                  - name
+                  - readOnly
+                  - source
+                  - unknownTags
+                  type: object
+                type: array
             type: object
         type: object
     served: true


### PR DESCRIPTION
- those guys deprecated entire `redpanda.vectorized.io` group, and moved to a `clusters.redpanda.com`, configuring it also became harder
- somehow running with developerMode, after some deep-diving
- console api, fixed incorrect references to loki and prometheus http servers