### PR TITLE
Feat/chart aws spot termination handler

### DIFF
--- a/charts/aws-spot-termination-handler/.helmignore
+++ b/charts/aws-spot-termination-handler/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/aws-spot-termination-handler/Chart.yaml
+++ b/charts/aws-spot-termination-handler/Chart.yaml
@@ -1,0 +1,24 @@
+apiVersion: v2
+name: aws-spot-termination-handler
+description: A Helm chart for Kubernetes
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.1.0
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+# It is recommended to use it with quotes.
+appVersion: "1.16.0"

--- a/charts/aws-spot-termination-handler/README.md
+++ b/charts/aws-spot-termination-handler/README.md
@@ -1,0 +1,71 @@
+# aws-spot-termination-handler
+
+[aws-spot-termination-handler](https://github.com/kloudlite.io/helm-charts/charts/aws-spot-termination-handler) A Helm chart for Kubernetes
+
+![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.16.0](https://img.shields.io/badge/AppVersion-1.16.0-informational?style=flat-square)
+
+## Get Repo Info
+
+```console
+helm repo add kloudlite https://kloudlite.github.io/helm-charts
+helm repo update
+```
+
+## Install Chart
+```console
+helm install [RELEASE_NAME] kloudlite/aws-spot-termination-handler --namespace [NAMESPACE]
+```
+
+The command deploys kloudlite-agent on the Kubernetes cluster in the default configuration.
+
+_See [configuration](#configuration) below._
+
+_See [helm install](https://helm.sh/docs/helm/helm_install/) for command documentation._
+
+## Installing Nightly Releases
+
+To list all nightly versions (**NOTE**: nightly versions are suffixed by `-nightly`)
+
+```console
+helm search repo kloudlite/aws-spot-termination-handler --devel
+```
+
+To install
+```console
+helm install  [RELEASE_NAME] kloudlite/aws-spot-termination-handler --version [NIGHTLY_VERSION] --namespace [NAMESPACE] --create-namespace
+```
+
+## Uninstall Chart
+
+```console
+helm uninstall [RELEASE_NAME] -n [NAMESPACE]
+```
+
+This removes all the Kubernetes components associated with the chart and deletes the release.
+
+_See [helm uninstall](https://helm.sh/docs/helm/helm_uninstall/) for command documentation._
+
+## Upgrading Chart
+
+```console
+helm upgrade [RELEASE_NAME] kloudlite/aws-spot-termination-handler
+```
+
+_See [helm upgrade](https://helm.sh/docs/helm/helm_upgrade/) for command documentation._
+
+## Configuration
+
+See [Customizing the Chart Before Installing](https://helm.sh/docs/intro/using_helm/#customizing-the-chart-before-installing). To see all configurable options with detailed comments, visit the chart's [values.yaml](./values.yaml), or run these configuration commands:
+
+```console
+helm show values kloudlite/aws-spot-termination-handler
+```
+
+## Values
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| image.name | string | `"ghcr.io/kloudlite/platform/aws-spot-k3s-termination-handler"` | kloudlite image repository, tag will be dervied from {{.kloudliteRelease}} |
+| kloudliteRelease | string | `"v1.0.5-nightly"` | kloudlite release identifier |
+| name | string | `"aws-spot-termination-handler"` |  |
+| nodeSelector | object | `{}` | node selector for the spot termination handler, it is required because it must be running only on aws spot instances |

--- a/charts/aws-spot-termination-handler/README.md.gotmpl
+++ b/charts/aws-spot-termination-handler/README.md.gotmpl
@@ -1,0 +1,66 @@
+{{- $chartRepo := "kloudlite" -}}
+{{- $chartName := .Name -}}
+
+{{ template "chart.header" . }}
+[{{$chartName}}](https://github.com/kloudlite.io/helm-charts/charts/{{$chartName}}) {{.Description}}
+
+{{ template "chart.versionBadge" . }}{{ template "chart.typeBadge" . }}{{ template "chart.appVersionBadge" . }}
+
+## Get Repo Info
+
+```console
+helm repo add kloudlite https://kloudlite.github.io/helm-charts
+helm repo update
+```
+
+## Install Chart
+```console
+helm install [RELEASE_NAME] kloudlite/{{$chartName}} --namespace [NAMESPACE]
+```
+
+The command deploys kloudlite-agent on the Kubernetes cluster in the default configuration.
+
+_See [configuration](#configuration) below._
+
+_See [helm install](https://helm.sh/docs/helm/helm_install/) for command documentation._
+
+## Installing Nightly Releases
+
+To list all nightly versions (**NOTE**: nightly versions are suffixed by `-nightly`)
+
+```console
+helm search repo kloudlite/{{$chartName}} --devel
+```
+
+To install
+```console
+helm install [RELEASE_NAME] kloudlite/{{$chartName}} --version [NIGHTLY_VERSION] --namespace [NAMESPACE] --create-namespace
+```
+
+## Uninstall Chart
+
+```console
+helm uninstall [RELEASE_NAME] -n [NAMESPACE]
+```
+
+This removes all the Kubernetes components associated with the chart and deletes the release.
+
+_See [helm uninstall](https://helm.sh/docs/helm/helm_uninstall/) for command documentation._
+
+## Upgrading Chart
+
+```console
+helm upgrade [RELEASE_NAME] kloudlite/{{$chartName}}
+```
+
+_See [helm upgrade](https://helm.sh/docs/helm/helm_upgrade/) for command documentation._
+
+## Configuration
+
+See [Customizing the Chart Before Installing](https://helm.sh/docs/intro/using_helm/#customizing-the-chart-before-installing). To see all configurable options with detailed comments, visit the chart's [values.yaml](./values.yaml), or run these configuration commands:
+
+```console
+helm show values {{$chartRepo}}/{{$chartName}}
+```
+
+{{ template "chart.valuesSection" . }}

--- a/charts/aws-spot-termination-handler/templates/NOTES.txt
+++ b/charts/aws-spot-termination-handler/templates/NOTES.txt
@@ -1,0 +1,6 @@
+Application is now polling for AWS metadata events.
+Once it receives a termination notice:
+  - it will gracefully drain the node
+  - and once it reaches t-10 seconds, it will delete the node from k8s
+
+And hopefully, aws spot fleet will replace the node with a new one

--- a/charts/aws-spot-termination-handler/templates/daemonset.yml.tpl
+++ b/charts/aws-spot-termination-handler/templates/daemonset.yml.tpl
@@ -1,0 +1,38 @@
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: &name {{.Values.name}}
+  namespace: {{.Release.Namespace}}
+  labels:
+    installed-by: kloudlite
+spec:
+  selector:
+    matchLabels:
+      name: *name
+  template:
+    metadata:
+      labels:
+        name: *name
+    spec:
+      serviceAccountName: {{.Values.name}}
+      nodeSelector: {{ .Values.nodeSelector | toYaml | nindent 10 }}
+      containers:
+      - name: main
+        image: {{.Values.image.name}}:{{.Values.kloudliteRelease}}
+        env:
+         - name: NODE_NAME
+           valueFrom:
+             fieldRef:
+               fieldPath: spec.nodeName
+         - name: DEBUG
+           value: "true"
+        resources:
+          limits:
+            memory: 50Mi
+            cpu: 50m
+          requests:
+            memory: 20Mi
+            cpu: 20m
+      terminationGracePeriodSeconds: 10
+---

--- a/charts/aws-spot-termination-handler/templates/rbac.yml.tpl
+++ b/charts/aws-spot-termination-handler/templates/rbac.yml.tpl
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: aws-spot-k3s-termination-handler
+  namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: aws-spot-k3s-termination-handler-rb
+subjects:
+  - kind: ServiceAccount
+    name: aws-spot-k3s-termination-handler
+    namespace: kube-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: "ClusterRole"
+  name: cluster-admin
+---

--- a/charts/aws-spot-termination-handler/values.yaml
+++ b/charts/aws-spot-termination-handler/values.yaml
@@ -1,0 +1,11 @@
+name: "aws-spot-termination-handler"
+
+# -- kloudlite release identifier
+kloudliteRelease: v1.0.5-nightly
+
+image:
+  # -- kloudlite image repository, tag will be dervied from {{.kloudliteRelease}}
+  name: ghcr.io/kloudlite/platform/aws-spot-k3s-termination-handler
+
+# -- node selector for the spot termination handler, it is required because it must be running only on aws spot instances
+nodeSelector: {}

--- a/charts/kloudlite-operators/templates/core-operators/routers.yml.tpl
+++ b/charts/kloudlite-operators/templates/core-operators/routers.yml.tpl
@@ -71,19 +71,11 @@ spec:
             - name: ACME_EMAIL
               value: {{.Values.acmeEmail}}
 
-            - name: DEFAULT_CLUSTER_ISSUER_NAME
-              value: ""
+            - name: WORKSPACE_ROUTE_SWITCHER_SERVICE
+              value: "ws-route-switcher"
 
-            - name: WILDCARD_CERT_NAME
-              {{/* value: {{.Values.cloudflareWildcardCert.secretName}} */}}
-              value: "asdfafj"
-
-            - name: WILDCARD_CERT_NAMESPACE
-              value: {{.Release.Namespace}}
-
-            - name: KLOUDLITE_ENV_ROUTE_SWITCHER
-              value: "env-route-switcher"
-
+            - name: WORKSPACE_ROUTE_SWITCHER_PORT
+              value: "80"
 
           image: {{.Values.operators.routers.image}}
           imagePullPolicy: {{.Values.operators.routers.ImagePullPolicy | default .Values.imagePullPolicy }}

--- a/charts/kloudlite-operators/values.yml.tpl
+++ b/charts/kloudlite-operators/values.yml.tpl
@@ -9,6 +9,9 @@ nodeSelector: {}
 
 # -- (array) tolerations for all pods in this chart
 tolerations: []
+  {{- /* - key: masters */}}
+  {{- /*   effect: "NoExecute" */}}
+  {{- /*   value: "true" */}}
 
 # -- (object) pod labels for all pods in this chart
 podLabels: {}

--- a/charts/kloudlite-platform/README.md
+++ b/charts/kloudlite-platform/README.md
@@ -140,12 +140,15 @@ helm show values kloudlite/kloudlite-platform
 | cloudflareWildCardCert.domains | list | `["*.platform.kloudlite.io"]` | list of all SANs (Subject Alternative Names) for which wildcard certs should be created |
 | cloudflareWildCardCert.name | string | `"kl-cert-wildcard"` | name for wildcard cert |
 | cloudflareWildCardCert.secretName | string | `"kl-cert-wildcard-tls"` | k8s secret where wildcard cert should be stored |
+| clusterInternalDNS | string | `"svc.cluster.local"` | cluster internal DNS name |
 | clusterIssuer.acmeEmail | string | `"sample@example.com"` | email that should be used for communicating with lets-encrypt services |
 | clusterIssuer.create | bool | `true` | whether to install cluster issuer |
 | clusterIssuer.name | string | `"cluster-issuer"` | name of cluster issuer, to be used for issuing wildcard cert |
 | clusterSvcAccount | string | `"kloudlite-cluster-svc-account"` | service account for privileged k8s operations, like creating namespaces, apps, routers etc. |
 | cookieDomain | string | `".platform.kloudlite.io"` | cookie domain dictates at what domain, the cookies should be set for auth or other purposes |
 | defaultProjectWorkspaceName | string | `"default"` | default project workspace name, the one that should be auto created, whenever you create a project |
+| helmCharts.cert-manager.enabled | bool | `true` |  |
+| helmCharts.cert-manager.name | string | `"cert-manager"` |  |
 | helmCharts.grafana.configuration.volumeSize | string | `"2Gi"` |  |
 | helmCharts.grafana.enabled | bool | `true` |  |
 | helmCharts.grafana.name | string | `"grafana"` |  |
@@ -185,6 +188,7 @@ helm show values kloudlite/kloudlite-platform
 | persistence.storageClasses.ext4 | string | `nil` |  |
 | persistence.storageClasses.xfs | string | `nil` |  |
 | podLabels | object | `{}` | podlabels for pods belonging to this release |
+| preferOperatorsOnMasterNodes | bool | `true` |  |
 | redpandaCluster | object | `{"create":true,"name":"redpanda","replicas":1,"resources":{"limits":{"cpu":"300m","memory":"400Mi"},"requests":{"cpu":"200m","memory":"200Mi"}},"storage":{"capacity":"2Gi"},"version":"v22.1.6"}` | redpanda cluster configuration, read more at https://vectorized.io/docs/quick-start-kubernetes |
 | routers.accountsWeb | object | `{}` |  |
 | routers.authWeb | object | `{}` |  |

--- a/charts/kloudlite-platform/Taskfile.yml
+++ b/charts/kloudlite-platform/Taskfile.yml
@@ -133,7 +133,10 @@ tasks:
       # consider using 128 chars secrets, you can use `python -c "import secrets; print(secrets.token_urlsafe(128))"`
       TokenHashingSecret: '<token-hashing-secret>'
 
+      PreferOperatorsOnMasterNodes: true
       EnableWgExamples: false
+
+      ContainerRegistrySecret: ""
     cmds:
       - task: cmd:setup
       - |+

--- a/charts/kloudlite-platform/templates/_kl-helpers.tpl
+++ b/charts/kloudlite-platform/templates/_kl-helpers.tpl
@@ -69,3 +69,24 @@ tolerations: {{ include "tolerations" . | nindent 2 }}
 {{- printf "%s-prometheus" .Release.Name | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
+
+{{- define "preferred-node-affinity-to-masters" -}}
+preferredDuringSchedulingIgnoredDuringExecution:
+  - weight: 1
+    preference:
+      matchExpressions:
+        - key: node-role.kubernetes.io/master
+          operator: In
+          values:
+            - "true"
+{{- end }}
+
+{{- define "required-node-affinity-to-masters" -}}
+requiredDuringSchedulingIgnoredDuringExecution:
+  nodeSelectorTerms:
+    - matchExpressions:
+        - key: node-role.kubernetes.io/master
+          operator: In
+          values:
+            - "true"
+{{- end }}

--- a/charts/kloudlite-platform/templates/apis/container-registry-api.yml.tpl
+++ b/charts/kloudlite-platform/templates/apis/container-registry-api.yml.tpl
@@ -16,6 +16,11 @@ spec:
       name: http
       type: tcp
 
+    - port: 4001
+      targetPort: {{.Values.apps.containerRegistryApi.configuration.grpcPort}}
+      name: grpc
+      type: tcp
+
     - port: {{.Values.apps.containerRegistryApi.configuration.grpcPort}}
       targetPort: {{.Values.apps.containerRegistryApi.configuration.grpcPort}}
       name: grpc
@@ -38,26 +43,20 @@ spec:
         - key: GRPC_PORT
           value: {{.Values.apps.containerRegistryApi.configuration.grpcPort | squote}}
 
+        - key: REGISTRY_EVENT_LISTNER_PORT
+          value: {{.Values.apps.containerRegistryApi.configuration.eventListenerPort | squote}}
+
+        - key: REGISTRY_AUTHORIZER_PORT
+          value: {{.Values.apps.containerRegistryApi.configuration.authorizerPort | squote}}
+
+        - key: REGISTRY_SECRET_KEY
+          value: {{.Values.apps.containerRegistryApi.configuration.registrySecret | squote}}
+
         - key: COOKIE_DOMAIN
           value: {{.Values.cookieDomain}}
 
         - key: ACCOUNT_COOKIE_NAME
           value: {{.Values.accountCookieName}}
-
-        - key: HARBOR_REGISTRY_HOST
-          type: secret
-          refName: {{.Values.secretNames.harborAdminSecret}}
-          refKey: IMAGE_REGISTRY_HOST
-
-        - key: HARBOR_ADMIN_USERNAME
-          type: secret
-          refName: {{.Values.secretNames.harborAdminSecret}}
-          refKey: ADMIN_USERNAME
-
-        - key: HARBOR_ADMIN_PASSWORD
-          type: secret
-          refName: {{.Values.secretNames.harborAdminSecret}}
-          refKey: ADMIN_PASSWORD
 
         - key: AUTH_REDIS_HOSTS
           type: secret
@@ -79,6 +78,29 @@ spec:
           refName: mres-{{.Values.managedResources.authRedis}}
           refKey: USERNAME
 
+        - key: REGISTRY_URL
+          value: http://{{(index .Values.helmCharts "container-registry").name }}.{{.Release.Namespace}}.{{.Values.clusterInternalDNS}}
+
+        - key: REGISTRY_REDIS_USERNAME
+          type: secret
+          refName: mres-{{.Values.managedResources.containerRegistryRedis}}
+          refKey: USERNAME
+
+        - key: REGISTRY_REDIS_PREFIX
+          type: secret
+          refName: mres-{{.Values.managedResources.containerRegistryRedis}}
+          refKey: PREFIX
+
+        - key: REGISTRY_REDIS_HOSTS
+          type: secret
+          refName: mres-{{.Values.managedResources.containerRegistryRedis}}
+          refKey: HOSTS
+
+        - key: REGISTRY_REDIS_PASSWORD
+          type: secret
+          refName: mres-{{.Values.managedResources.containerRegistryRedis}}
+          refKey: PASSWORD
+
         - key: DB_URI
           type: secret
           refName: mres-{{.Values.managedResources.containerRegistryDb}}
@@ -86,5 +108,8 @@ spec:
 
         - key: DB_NAME
           value: {{.Values.managedResources.containerRegistryDb}}
+
+        - key: IAM_GRPC_ADDR
+          value: {{.Values.apps.iamApi.name}}.{{.Release.Namespace}}.{{.Values.clusterInternalDNS}}:{{.Values.apps.iamApi.configuration.grpcPort}}
 ---
 {{- end }}

--- a/charts/kloudlite-platform/templates/apis/infra-api.yml.tpl
+++ b/charts/kloudlite-platform/templates/apis/infra-api.yml.tpl
@@ -31,7 +31,7 @@ spec:
         {{- /* - key: FINANCE_GRPC_ADDR */}}
         {{- /*   value: http://{{.Values.apps.financeApi.name}}:3001 */}}
         - key: ACCOUNTS_GRPC_ADDR
-          value: http://{{.Values.apps.accountsApi.name}}:{{.Values.apps.accountsApi.configuration.grpcPort}}
+          value: {{.Values.apps.accountsApi.name}}:{{.Values.apps.accountsApi.configuration.grpcPort}}
 
         - key: INFRA_DB_NAME
           value: {{.Values.managedResources.infraDb}}

--- a/charts/kloudlite-platform/templates/helm-charts/helm-grafana.yml.tpl
+++ b/charts/kloudlite-platform/templates/helm-charts/helm-grafana.yml.tpl
@@ -20,6 +20,8 @@ spec:
     nameOverride: {{$chartOpts.name}}
     fullnameOverride: {{$chartOpts.name}}
 
+    nodeSelector: {{$chartOpts.configuration.nodeSelector}}
+
     persistence:
       enabled: true
       size: {{$chartOpts.configuration.volumeSize}}

--- a/charts/kloudlite-platform/templates/helm-charts/helm-ingress-nginx.yml.tpl
+++ b/charts/kloudlite-platform/templates/helm-charts/helm-ingress-nginx.yml.tpl
@@ -12,7 +12,8 @@ spec:
     url: https://kubernetes.github.io/ingress-nginx
 
   chartName: ingress-nginx/ingress-nginx
-  chartVersion: 4.8.0
+  {{- /* chartVersion: 4.8.0 */}}
+  chartVersion: 4.6.0
 
   valuesYaml: |+
     nameOverride: {{$chartOpts.name}}
@@ -46,8 +47,9 @@ spec:
           healthz: 10254
 
       dnsPolicy: ClusterFirstWithHostNet
-      nodeSelector:
-        node-role.kubernetes.io/control-plane: "true"
+
+      tolerations: {{ $chartOpts.configuration.tolerations | toYaml | nindent 8 }}
+      nodeSelector: {{ $chartOpts.configuration.nodeSelector | toYaml | nindent 8 }}
       affinity: {{$chartOpts.configuration.affinity | toYaml | nindent 8 }}
       {{- end }}
 

--- a/charts/kloudlite-platform/templates/helm-charts/helm-kube-prometheus.yml.tpl
+++ b/charts/kloudlite-platform/templates/helm-charts/helm-kube-prometheus.yml.tpl
@@ -45,6 +45,8 @@ spec:
         size: {{$chartOpts.configuration.prometheus.volumeSize}}
       paused: false
 
+      nodeSelector: {{$chartOpts.configuration.prometheus.nodeSelector | toYaml |nindent 10}}
+
       additionalScrapeConfigs:
         enabled: true
         type: internal
@@ -86,6 +88,8 @@ spec:
         enabled: true
         size: {{$chartOpts.configuration.prometheus.volumeSize}}
       paused: false
+
+      nodeSelector: {{$chartOpts.configuration.prometheus.nodeSelector | toYaml |nindent 10}}
     
     exporters:
       node-exporter:

--- a/charts/kloudlite-platform/templates/mres/redis-acl-container-registry.yml.tpl
+++ b/charts/kloudlite-platform/templates/mres/redis-acl-container-registry.yml.tpl
@@ -1,0 +1,17 @@
+---
+apiVersion: crds.kloudlite.io/v1
+kind: ManagedResource
+metadata:
+  name: {{.Values.managedResources.containerRegistryRedis}}
+  namespace: {{.Release.Namespace}}
+spec:
+  inputs:
+    keyPrefix: container-registry
+  mresKind:
+    kind: ACLAccount
+  msvcRef:
+    apiVersion: redis.msvc.kloudlite.io/v1
+    kind: StandaloneService
+    name: {{.Values.managedServices.redisSvc}}
+
+---

--- a/charts/kloudlite-platform/templates/msvc/mongo-svc.yml.tpl
+++ b/charts/kloudlite-platform/templates/msvc/mongo-svc.yml.tpl
@@ -4,6 +4,7 @@ metadata:
   name: {{.Values.managedServices.mongoSvc}}
   namespace: {{.Release.Namespace}}
 spec:
+  nodeSelector: {{.Values.managedServicesNodeSelector |toYaml | nindent 6 }}
   msvcKind:
     apiVersion: mongodb.msvc.kloudlite.io/v1
     kind: StandaloneService

--- a/charts/kloudlite-platform/templates/msvc/redis-svc.yml.tpl
+++ b/charts/kloudlite-platform/templates/msvc/redis-svc.yml.tpl
@@ -4,6 +4,7 @@ metadata:
   name: {{.Values.managedServices.redisSvc}}
   namespace: {{.Release.Namespace}}
 spec:
+  nodeSelector: {{.Values.managedServicesNodeSelector |toYaml | nindent 6 }}
   msvcKind:
     apiVersion: redis.msvc.kloudlite.io/v1
     kind: StandaloneService

--- a/charts/kloudlite-platform/templates/operators/account-operator.yml.tpl
+++ b/charts/kloudlite-platform/templates/operators/account-operator.yml.tpl
@@ -30,6 +30,11 @@ spec:
       nodeSelector: {{.Values.nodeSelector | toYaml | nindent 8}}
       {{- end }}
 
+      {{- if .Values.preferOperatorsOnMasterNodes }}
+      affinity:
+        nodeAffinity: {{include "preferred-node-affinity-to-masters" . | nindent 10 }}
+      {{- end }}
+
       containers:
         - args:
             - --secure-listen-address=0.0.0.0:8443

--- a/charts/kloudlite-platform/templates/operators/byoc-operator.yml.tpl
+++ b/charts/kloudlite-platform/templates/operators/byoc-operator.yml.tpl
@@ -35,6 +35,10 @@ spec:
       labels:
         control-plane: {{.Values.operators.byocOperator.name}}
     spec:
+      {{- if .Values.preferOperatorsOnMasterNodes }}
+      affinity:
+        nodeAffinity: {{include "preferred-node-affinity-to-masters" . | nindent 10 }}
+      {{- end }}
       containers:
         - args:
             - --secure-listen-address=0.0.0.0:8443

--- a/charts/kloudlite-platform/templates/operators/wg-operator.yml.tpl
+++ b/charts/kloudlite-platform/templates/operators/wg-operator.yml.tpl
@@ -57,6 +57,10 @@ spec:
                     operator: In
                     values:
                       - linux
+
+        {{- if .Values.preferOperatorsOnMasterNodes }}
+        {{include "preferred-node-affinity-to-masters" . | nindent 10 }}
+        {{- end }}
       containers:
         - args:
             - --secure-listen-address=0.0.0.0:8443
@@ -102,7 +106,7 @@ spec:
               value: {{.Values.operators.wgOperator.configuration.svcCIDR}}
 
             - name: DNS_HOSTED_ZONE
-              value: {{.Values.operators.wgOperator.configuration.dnsHostedZone}}
+              value: {{.Values.baseDomain}}
 
           image: {{.Values.operators.wgOperator.image}}
           imagePullPolicy: {{.Values.operators.wgOperator.ImagePullPolicy | default .Values.imagePullPolicy }}

--- a/charts/kloudlite-platform/templates/redpanda/redpanda-cluster.yml.tpl
+++ b/charts/kloudlite-platform/templates/redpanda/redpanda-cluster.yml.tpl
@@ -22,6 +22,7 @@ spec:
 
     statefulset:
       replicas: 1
+      nodeSelector: {{.Values.managedServicesNodeSelector | toYaml | nindent 10 }}
       additionalRedpandaCmdFlags:
         - --mode
         - dev-container

--- a/charts/kloudlite-platform/values.yaml
+++ b/charts/kloudlite-platform/values.yaml
@@ -27,13 +27,16 @@ accountCookieName: "kloudlite-account"
 clusterCookieName: "kloudlite-cluster"
 
 # -- service account for privileged k8s operations, like creating namespaces, apps, routers etc.
-clusterSvcAccount: kloudlite-cluster-svc-account
+clusterSvcAccount: kloudlite-cluster-svc-accountval
 
 # -- service account for non k8s operations, just for specifying image pull secrets
 normalSvcAccount: kloudlite-svc-account
 
 # -- default project workspace name, the one that should be auto created, whenever you create a project
 defaultProjectWorkspaceName: "default"
+
+managedServicesNodeSelector: &msvc-node-selector
+  kloudlite.io/cloud-provider.az: ap-south-1a
 
 helmCharts:
   cert-manager:
@@ -48,6 +51,14 @@ helmCharts:
       # -- can be DaemonSet or Deployment
       controllerKind: "Deployment"
       ingressClassName: "ingress-nginx"
+
+      nodeSelector: 
+        node-role.kubernetes.io/control-plane: "true"
+
+      tolerations:
+        - key: masters
+          value: "true"
+          effect: NoExecute
 
 
   loki-stack:
@@ -84,6 +95,7 @@ helmCharts:
 
     configuration:
       volumeSize: 2Gi
+      nodeSelector: *msvc-node-selector
 
   kube-prometheus:
     enabled: true
@@ -92,8 +104,14 @@ helmCharts:
     configuration:
       prometheus:
         volumeSize: 2Gi
+        nodeSelector: *msvc-node-selector
       alertmanager:
         volumeSize: 2Gi
+        nodeSelector: *msvc-node-selector
+
+  container-registry:
+    enabled: true
+    name: container-registry
 
 persistence:
   storageClasses:
@@ -220,7 +238,9 @@ managedResources:
 
   socketWebRedis: socket-web-redis
   eventsDb: events-db
+
   containerRegistryDb: container-registry-db
+  containerRegistryRedis: container-registry-redis
 
 routers:
   authWeb:
@@ -359,10 +379,10 @@ apps:
       grpcPort: 3001
 
       # -- account web invite url
-      accountsWebInviteUrl: https://accounts.platform.kloudlite.io/invite
+      accountsWebInviteUrl: https://auth.platform.kloudlite.io/invite
 
       # -- project web invite url
-      projectsWebInviteUrl: https://projects.platform.kloudlite.io/invite
+      projectsWebInviteUrl: https://auth.platform.kloudlite.io/invite
 
       # -- console web invite url
       kloudliteConsoleWebUrl: https://console.platform.kloudlite.io
@@ -432,7 +452,7 @@ apps:
     image: ghcr.io/kloudlite/platform/apis/gateway:v1.0.5-nightly
 
   containerRegistryApi:
-    enabled: false
+    enabled: true
 
     # @ignored
     # -- workload name for container registry api
@@ -445,9 +465,17 @@ apps:
       # @ignored
       # -- (number) port on which container registry api should listen
       httpPort: 3000
+
+      # -- (number) port on which container registry event listener should listen
+      eventListenerPort: 4001
+
       # -- (number) port on which container registry grpc api should listen
       # @ignored
       grpcPort: 3001
+
+      registrySecret: ""
+
+      authorizerPort: 4000
 
       # -- harbor configuration, required only if .apps.containerRegistryApi.enabled
       harbor: &harborConfiguration
@@ -533,6 +561,7 @@ apps:
       # -- consider using 128 characters random string, you can use `python -c "import secrets; print(secrets.token_urlsafe(128))"`
       tokenHashingSecret: <token-hashing-secret>
 
+preferOperatorsOnMasterNodes: true
 operators:
   # -- kloudlite account operator
   accountOperator:


### PR DESCRIPTION
-  Kloudlite platform. New resources, including the Container Registry API and Container Registry Redis managed service, have been added. Additionally, managed services now come with node selectors to ensure they reside in the same Availability Zone (AZ) as their associated Persistent Volume Claims (PVCs), improving resource management.

- fix has been applied to the kloudlite operators chart. Specifically, it resolves an issue where the Router Operator was missing essential environment variables, ensuring smoother and more reliable operation.

- implements AWS Spot Termination Handler. It  sets up a DaemonSet to monitor AWS spot termination events. When such an event occurs, the handler takes appropriate actions, making our system more resilient in AWS spot instances scenarios.