### PR TITLE
kloudlite agent now tolerations taints for master nodes

### DIFF
--- a/charts/kloudlite-agent/templates/agent/kl-agent.yml.tpl
+++ b/charts/kloudlite-agent/templates/agent/kl-agent.yml.tpl
@@ -13,6 +13,10 @@ spec:
     - port: 6000
       targetPort: 6000
       name: grpc
+  tolerations:
+    - key: "node-role.kubernetes.io/master"
+      operator: "Exists"
+      effect: "NoSchedule"
   containers:
     - name: main
       image: {{.Values.agent.image}}

--- a/charts/kloudlite-agent/templates/operators/resource-watcher.yml.tpl
+++ b/charts/kloudlite-agent/templates/operators/resource-watcher.yml.tpl
@@ -123,7 +123,9 @@ spec:
               memory: 20Mi
       serviceAccountName: {{include "serviceAccountName" .}}
       terminationGracePeriodSeconds: 10
+
 ---
+
 apiVersion: v1
 kind: Service
 metadata:

--- a/charts/kloudlite-platform/Taskfile.yml
+++ b/charts/kloudlite-platform/Taskfile.yml
@@ -50,6 +50,9 @@ tasks:
       HarborWebhookName: "kloudlite-{{.InstallationMode}}-webhook"
       ImagePullSecret: '<image-pull-secret>'
 
+      AccountName: "kloudlite"
+      ClusterName: "platform" 
+
       SendgridAPIKey: ""
       SupportEmail: ''
       Ext4StorageClassName: ""
@@ -114,7 +117,9 @@ tasks:
       ImageConsoleWeb: "{{.ImagePrefix}}/platform/web/console-web:{{.ImageVersionTag}}"
       ImageSocketWeb: "{{.ImagePrefix}}/platform/web/socket-web:{{.ImageVersionTag}}"
 
+      # operators
       ImageWgOperator: "{{.ImagePrefix}}/operators/wireguard:{{.ImageVersionTag}}"
+      ImageResourceWatcher: "{{.ImagePrefix}}/operators/resource-watcher:{{.ImageVersionTag}}"
 
       WgDnsHostedZone: "<dns-hosted-zone>"
       WgPodCIDR: '10.42.0.0/16'

--- a/charts/kloudlite-platform/templates/apis/accounts-api.yml.tpl
+++ b/charts/kloudlite-platform/templates/apis/accounts-api.yml.tpl
@@ -67,17 +67,17 @@ spec:
           value: "{{.Values.cookieDomain}}"
 
         - key: IAM_GRPC_ADDR
-          value: "{{.Values.apps.iamApi.name}}.{{.Release.Namespace}}.{{.Values.clusterInternalDNS}}:{{.Values.apps.iamApi.configuration.grpcPort}}"
+          value: "{{.Values.apps.iamApi.name}}.{{.Release.Namespace}}.svc.{{.Values.clusterInternalDNS}}:{{.Values.apps.iamApi.configuration.grpcPort}}"
 
         - key: COMMS_GRPC_ADDR
-          value: "{{.Values.apps.commsApi.name}}.{{.Release.Namespace}}.{{.Values.clusterInternalDNS}}:{{.Values.apps.commsApi.configuration.grpcPort}}"
+          value: "{{.Values.apps.commsApi.name}}.{{.Release.Namespace}}.svc.{{.Values.clusterInternalDNS}}:{{.Values.apps.commsApi.configuration.grpcPort}}"
 
         - key: CONTAINER_REGISTRY_GRPC_ADDR
-          value: "{{.Values.apps.containerRegistryApi.name}}.{{.Release.Namespace}}.{{.Values.clusterInternalDNS}}:{{.Values.apps.containerRegistryApi.configuration.grpcPort}}"
+          value: "{{.Values.apps.containerRegistryApi.name}}.{{.Release.Namespace}}.svc.{{.Values.clusterInternalDNS}}:{{.Values.apps.containerRegistryApi.configuration.grpcPort}}"
 
         - key: CONSOLE_GRPC_ADDR
-          value: "{{.Values.apps.consoleApi.name}}.{{.Release.Namespace}}.{{.Values.clusterInternalDNS}}:{{.Values.apps.consoleApi.configuration.grpcPort}}"
+          value: "{{.Values.apps.consoleApi.name}}.{{.Release.Namespace}}.svc.{{.Values.clusterInternalDNS}}:{{.Values.apps.consoleApi.configuration.grpcPort}}"
 
         - key: AUTH_GRPC_ADDR
-          value: "{{.Values.apps.authApi.name}}.{{.Release.Namespace}}.{{.Values.clusterInternalDNS}}:{{.Values.apps.authApi.configuration.grpcPort}}"
+          value: "{{.Values.apps.authApi.name}}.{{.Release.Namespace}}.svc.{{.Values.clusterInternalDNS}}:{{.Values.apps.authApi.configuration.grpcPort}}"
 

--- a/charts/kloudlite-platform/templates/apis/console-api.yml.tpl
+++ b/charts/kloudlite-platform/templates/apis/console-api.yml.tpl
@@ -100,10 +100,10 @@ spec:
           value: {{.Values.kafka.consumerGroupId}}
 
         - key: IAM_GRPC_ADDR
-          value: {{.Values.apps.iamApi.name}}.{{.Release.Namespace}}.{{.Values.clusterInternalDNS}}:{{.Values.apps.iamApi.configuration.grpcPort}}
+          value: {{.Values.apps.iamApi.name}}.{{.Release.Namespace}}.svc.{{.Values.clusterInternalDNS}}:{{.Values.apps.iamApi.configuration.grpcPort}}
 
         - key: INFRA_GRPC_ADDR
-          value: {{.Values.apps.infraApi.name}}.{{.Release.Namespace}}.{{.Values.clusterInternalDNS}}:{{.Values.apps.infraApi.configuration.grpcPort}}
+          value: {{.Values.apps.infraApi.name}}.{{.Release.Namespace}}.svc.{{.Values.clusterInternalDNS}}:{{.Values.apps.infraApi.configuration.grpcPort}}
 
         - key: DEFAULT_PROJECT_WORKSPACE_NAME
           value: {{.Values.defaultProjectWorkspaceName}}
@@ -112,10 +112,10 @@ spec:
           value: /console.d/templates/managed-svc-templates.yml
 
         - key: LOKI_SERVER_HTTP_ADDR
-          value: http://{{ (index .Values.helmCharts "loki-stack").name }}.{{.Release.Namespace}}.{{.Values.clusterInternalDNS}}:3100
+          value: http://{{ (index .Values.helmCharts "loki-stack").name }}.{{.Release.Namespace}}.svc.{{.Values.clusterInternalDNS}}:3100
 
         - key: PROM_HTTP_ADDR
-          value: http://{{ (index .Values.helmCharts "kube-prometheus").name }}-prometheus.{{.Release.Namespace}}.{{.Values.clusterInternalDNS}}:9090
+          value: http://{{ (index .Values.helmCharts "kube-prometheus").name }}-prometheus.{{.Release.Namespace}}.svc.{{.Values.clusterInternalDNS}}:9090
 
         - key: VPN_DEVICES_MAX_OFFSET
           value: {{.Values.apps.consoleApi.configuration.vpnDevicesMaxOffset | squote}}
@@ -124,7 +124,7 @@ spec:
           value: {{.Values.apps.consoleApi.configuration.vpnDevicesOffsetStart | squote}}
 
         - key: PROM_HTTP_ADDR
-          value: http://{{ (index .Values.helmCharts "kube-prometheus").name }}-prometheus.{{.Release.Namespace}}.{{.Values.clusterInternalDNS}}:9090
+          value: http://{{ (index .Values.helmCharts "kube-prometheus").name }}-prometheus.{{.Release.Namespace}}.svc.{{.Values.clusterInternalDNS}}:9090
 
       volumes:
         - mountPath: /console.d/templates

--- a/charts/kloudlite-platform/templates/apis/container-registry-api.yml.tpl
+++ b/charts/kloudlite-platform/templates/apis/container-registry-api.yml.tpl
@@ -79,7 +79,7 @@ spec:
           refKey: USERNAME
 
         - key: REGISTRY_URL
-          value: http://{{(index .Values.helmCharts "container-registry").name }}.{{.Release.Namespace}}.{{.Values.clusterInternalDNS}}
+          value: http://{{(index .Values.helmCharts "container-registry").name }}.{{.Release.Namespace}}.svc.{{.Values.clusterInternalDNS}}
 
         - key: REGISTRY_REDIS_USERNAME
           type: secret
@@ -110,6 +110,6 @@ spec:
           value: {{.Values.managedResources.containerRegistryDb}}
 
         - key: IAM_GRPC_ADDR
-          value: {{.Values.apps.iamApi.name}}.{{.Release.Namespace}}.{{.Values.clusterInternalDNS}}:{{.Values.apps.iamApi.configuration.grpcPort}}
+          value: {{.Values.apps.iamApi.name}}.{{.Release.Namespace}}.svc.{{.Values.clusterInternalDNS}}:{{.Values.apps.iamApi.configuration.grpcPort}}
 ---
 {{- end }}

--- a/charts/kloudlite-platform/templates/apis/infra-api.yml.tpl
+++ b/charts/kloudlite-platform/templates/apis/infra-api.yml.tpl
@@ -42,7 +42,7 @@ spec:
           refKey: URI
 
         - key: HTTP_PORT
-          value: {{.Values.apps.infraApi.configuration.httpPort | squote}}
+          value: "3000"
 
         - key: GRPC_PORT
           value: {{.Values.apps.infraApi.configuration.grpcPort | squote}}

--- a/charts/kloudlite-platform/templates/apis/infra-api.yml.tpl
+++ b/charts/kloudlite-platform/templates/apis/infra-api.yml.tpl
@@ -47,9 +47,6 @@ spec:
         - key: GRPC_PORT
           value: {{.Values.apps.infraApi.configuration.grpcPort | squote}}
 
-        - key: GRPC_PORT
-          value: {{.Values.apps.infraApi.configuration.grpcPort | squote}}
-
         - key: COOKIE_DOMAIN
           value: "{{.Values.cookieDomain}}"
 

--- a/charts/kloudlite-platform/templates/apis/infra-api.yml.tpl
+++ b/charts/kloudlite-platform/templates/apis/infra-api.yml.tpl
@@ -42,7 +42,10 @@ spec:
           refKey: URI
 
         - key: HTTP_PORT
-          value: "3000"
+          value: {{.Values.apps.infraApi.configuration.httpPort | squote}}
+
+        - key: GRPC_PORT
+          value: {{.Values.apps.infraApi.configuration.grpcPort | squote}}
 
         - key: GRPC_PORT
           value: {{.Values.apps.infraApi.configuration.grpcPort | squote}}

--- a/charts/kloudlite-platform/templates/apis/infra-api.yml.tpl
+++ b/charts/kloudlite-platform/templates/apis/infra-api.yml.tpl
@@ -104,7 +104,7 @@ spec:
           value: {{.Release.Namespace}}
 
         - key: IAM_GRPC_ADDR
-          value: {{.Values.apps.iamApi.name}}.{{.Release.Namespace}}.{{.Values.clusterInternalDNS}}:{{.Values.apps.iamApi.configuration.grpcPort}}
+          value: {{.Values.apps.iamApi.name}}.{{.Release.Namespace}}.svc.{{.Values.clusterInternalDNS}}:{{.Values.apps.iamApi.configuration.grpcPort}}
 
         - key: MESSAGE_OFFICE_INTERNAL_GRPC_ADDR
           value: {{.Values.apps.messageOfficeApi.name}}.{{.Release.Namespace}}.{{.Values.clusterInternalDNS}}:{{.Values.apps.messageOfficeApi.configuration.internalGrpcPort}}

--- a/charts/kloudlite-platform/templates/operators/resource-watcher.yml.tpl
+++ b/charts/kloudlite-platform/templates/operators/resource-watcher.yml.tpl
@@ -1,0 +1,137 @@
+{{if .Values.operators.resourceWatcher.enabled}}
+{{ $name := .Values.operators.resourceWatcher.name }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/component: kube-rbac-proxy
+    app.kubernetes.io/name: service
+    app.kubernetes.io/part-of: {{$name}}
+    control-plane: {{$name}}
+  name: {{$name}}
+  namespace: {{.Release.Namespace}}
+spec:
+  ports:
+    - name: https
+      port: 8443
+      protocol: TCP
+      targetPort: https
+  selector:
+    control-plane: {{$name}}
+
+---
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.kubernetes.io/component: manager
+    app.kubernetes.io/name: deployment
+    app.kubernetes.io/part-of: {{$name}}
+    control-plane: {{$name}}
+  name: {{$name}}
+  namespace: {{.Release.Namespace}}
+spec:
+  replicas: 1
+  selector:
+    matchLabels: &labels
+      control-plane: {{$name}}
+  template:
+    metadata:
+      annotations:
+        kubectl.kubernetes.io/default-container: manager
+      labels: *labels
+    spec:
+      affinity:
+        nodeAffinity:
+          {{- if .Values.preferOperatorsOnMasterNodes }}
+          {{include "preferred-node-affinity-to-masters" . | nindent 10 }}
+          {{- end }}
+      containers:
+        - args:
+            - --secure-listen-address=0.0.0.0:8443
+            - --upstream=http://127.0.0.1:8080/
+            - --logtostderr=true
+            - --v=0
+          image: gcr.io/kubebuilder/kube-rbac-proxy:v0.13.0
+          name: kube-rbac-proxy
+          ports:
+            - containerPort: 8443
+              name: https
+              protocol: TCP
+          resources:
+            limits:
+              cpu: 30m
+              memory: 30Mi
+            requests:
+              cpu: 20m
+              memory: 20Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+        - args:
+            - --health-probe-bind-address=:8081
+            - --metrics-bind-address=127.0.0.1:8080
+            - --leader-elect
+            - --running-on-platform
+          command:
+            - /manager
+          env:
+            - name: RECONCILE_PERIOD
+              value: "30s"
+              
+            - name: MAX_CONCURRENT_RECONCILES
+              value: "5"
+
+            - name: ACCOUNT_NAME
+              value: {{.Values.accountName | squote}}
+
+            - name: CLUSTER_NAME
+              value: {{.Values.clusterName | squote}}
+
+            - name: KAFKA_BROKERS
+              value: redpanda.kl-core.svc.cluster.local:9092
+
+            - name: KAFKA_RESOURCE_UPDATES_TOPIC
+              value: {{.Values.kafka.topicStatusUpdates}}
+
+            - name: KAFKA_INFRA_UPDATES_TOPIC
+              value: {{.Values.kafka.topicInfraStatusUpdates}}
+
+          image: {{.Values.operators.resourceWatcher.image}}
+          imagePullPolicy: {{.Values.operators.resourceWatcher.ImagePullPolicy | default .Values.imagePullPolicy }}
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 8081
+            initialDelaySeconds: 15
+            periodSeconds: 20
+          name: manager
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: 8081
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          resources:
+            limits:
+              cpu: 100m
+              memory: 100Mi
+            requests:
+              cpu: 100m
+              memory: 100Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+      securityContext:
+        runAsNonRoot: true
+      serviceAccountName: {{.Values.clusterSvcAccount | squote}}
+      terminationGracePeriodSeconds: 10
+
+---
+{{ end }}

--- a/charts/kloudlite-platform/templates/redpanda/admin/redpanda-admin.yml.tpl
+++ b/charts/kloudlite-platform/templates/redpanda/admin/redpanda-admin.yml.tpl
@@ -7,7 +7,7 @@ spec:
   adminEndpoint: {{.Values.redpandaCluster.name}}.{{.Release.Namespace}}.svc.cluster.local:9644
   {{- $kafkaBrokers := list }} 
   {{- range $i, $e := until (int .Values.redpandaCluster.replicas) }}
-  {{- $kafkaBrokers = append $kafkaBrokers (printf "%s-%d.%s.%s.%s:9092" $.Values.redpandaCluster.name $i $.Values.redpandaCluster.name $.Release.Namespace $.Values.clusterInternalDNS) }}
+  {{- $kafkaBrokers = append $kafkaBrokers (printf "%s-%d.%s.%s.svc.%s:9092" $.Values.redpandaCluster.name $i $.Values.redpandaCluster.name $.Release.Namespace $.Values.clusterInternalDNS) }}
   {{- end }}
   {{- /* kafkaBrokers: {{.Values.redpandaCluster.name}}-0.{{.Values.redpandaCluster.name}}.{{.Release.Namespace}}.svc.cluster.local:9092 */}}
   kafkaBrokers: {{ join "," $kafkaBrokers }}

--- a/charts/kloudlite-platform/values.yaml
+++ b/charts/kloudlite-platform/values.yaml
@@ -15,8 +15,14 @@ cookieDomain: '.platform.kloudlite.io'
 # -- base domain for all routers exposed through this cluster
 baseDomain: 'platform.kloudlite.io'
 
+# -- kloudlite account name, required only for labelling purposes, does not need to be a real kloudlite account name
+accountName: 'kloudlite'
+
+# -- kloudlite cluster name, required only for labelling purposes, does not need to be a real kloudlite cluster name
+clusterName: 'platform'
+
 # -- cluster internal DNS name
-clusterInternalDNS: "svc.cluster.local"
+clusterInternalDNS: "cluster.local"
 
 # @ignored
 # -- account cookie name, that console-api should expect, while any client communicates through it's graphql interface
@@ -27,7 +33,7 @@ accountCookieName: "kloudlite-account"
 clusterCookieName: "kloudlite-cluster"
 
 # -- service account for privileged k8s operations, like creating namespaces, apps, routers etc.
-clusterSvcAccount: kloudlite-cluster-svc-accountval
+clusterSvcAccount: kloudlite-cluster-svc-account
 
 # -- service account for non k8s operations, just for specifying image pull secrets
 normalSvcAccount: kloudlite-svc-account
@@ -87,6 +93,10 @@ helmCharts:
         requests:
           cpu: 40m
           memory: 40Mi
+
+  strimzi-operator:
+    enabled: true
+    name: strimzi-operator
 
   vector:
     enabled: true
@@ -216,6 +226,14 @@ managedServices:
   mongoSvc: mongo-svc
   redisSvc: redis-svc
 
+  kafkaSvc:
+    enabled: false
+    name: kafka
+    configuration:
+      persistence:
+        storageClass: 
+        size: 5Gi
+
 # @ignored
 managedResources:
   authDb: auth-db
@@ -301,6 +319,7 @@ apps:
     image: ghcr.io/kloudlite/platform/apis/auth:v1.0.5-nightly
 
     configuration:
+      grpcPort: 3001
       oAuth2:
         # -- whether to enable oAuth2
         enabled: false
@@ -411,6 +430,9 @@ apps:
       grpcPort: 3001
       # @ignored
       logsAndMetricsHttpPort: 9100
+
+      vpnDevicesMaxOffset: 255
+      vpnDevicesOffsetStart: 5
 
   accountsApi:
     # @ignored
@@ -575,6 +597,7 @@ apps:
       tokenHashingSecret: <token-hashing-secret>
 
 preferOperatorsOnMasterNodes: true
+
 operators:
   # -- kloudlite account operator
   accountOperator:
@@ -616,4 +639,12 @@ operators:
       dnsHostedZone: <dns-hosted-zone>
 
       enableExamples: false
+  
+  resourceWatcher:
+    # -- whether to enable resource watcher
+    enabled: true
+    # -- resource watcher workload name
+    name: resource-watcher
 
+    # -- resource watcher image
+    image: "ghcr.io/kloudlite/operators/resource-watcher:v1.0.5-nightly"

--- a/charts/kloudlite-platform/values.yml.tpl
+++ b/charts/kloudlite-platform/values.yml.tpl
@@ -15,8 +15,14 @@ cookieDomain: {{.CookieDomain | squote}}
 # -- base domain for all routers exposed through this cluster
 baseDomain: {{.BaseDomain | squote }}
 
+# -- kloudlite account name, required only for labelling purposes, does not need to be a real kloudlite account name
+accountName: {{.AccountName | squote}}
+
+# -- kloudlite cluster name, required only for labelling purposes, does not need to be a real kloudlite cluster name
+clusterName: {{.ClusterName | squote}}
+
 # -- cluster internal DNS name
-clusterInternalDNS: "svc.cluster.local"
+clusterInternalDNS: "cluster.local"
 
 # @ignored
 # -- account cookie name, that console-api should expect, while any client communicates through it's graphql interface
@@ -27,7 +33,7 @@ accountCookieName: "kloudlite-account"
 clusterCookieName: "kloudlite-cluster"
 
 # -- service account for privileged k8s operations, like creating namespaces, apps, routers etc.
-clusterSvcAccount: {{.ClusterSvcAccount}}val
+clusterSvcAccount: {{.ClusterSvcAccount}}
 
 # -- service account for non k8s operations, just for specifying image pull secrets
 normalSvcAccount: {{.NormalSvcAccount}}
@@ -592,6 +598,7 @@ apps:
       tokenHashingSecret: {{.TokenHashingSecret}}
 
 preferOperatorsOnMasterNodes: {{.PreferOperatorsOnMasterNodes}}
+
 operators:
   # -- kloudlite account operator
   accountOperator:
@@ -633,4 +640,12 @@ operators:
       dnsHostedZone: {{.WgDnsHostedZone}}
 
       enableExamples: {{.EnableWgExamples}}
+  
+  resourceWatcher:
+    # -- whether to enable resource watcher
+    enabled: true
+    # -- resource watcher workload name
+    name: resource-watcher
 
+    # -- resource watcher image
+    image: "{{.ImageResourceWatcher}}"


### PR DESCRIPTION
- **feat(charts/kloudlite-platform): platform now has their own resource watcher**
  - Updates to clusterInternalDNS name, TIL "svc." is not a part of cluster internal DNS name

- **feat(charts/kloudlite-agent): agent now has tolerations for master nodes**