### PR TITLE
fix(charts/kloudlite-autoscalers): fixing optional envs

### DIFF
--- a/charts/kloudlite-autoscalers/templates/nodepool-operator.yml.tpl
+++ b/charts/kloudlite-autoscalers/templates/nodepool-operator.yml.tpl
@@ -1,16 +1,16 @@
 {{if .Values.nodepools.enabled}}
 
 {{- $name := "kl-nodepool-operator" }} 
+{{- $providerCreds := "cloudprovider-credentials" }} 
 ---
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{.Values.cloudprovider.secretName}}
+  name: {{$providerCreds}}
   namespace: {{.Release.Namespace}}
 data:
-  {{range $k, $v := .Values.cloudprovider.values}}
-  {{$k}}: {{ $v | b64enc }}
-  {{- end }}
+  accessKey: "{{ .Values.cloudprovider.accessKey | b64enc }}"
+  secretKey: "{{ .Values.cloudprovider.secretKey | b64enc }}"
 ---
 apiVersion: v1
 kind: Service
@@ -103,16 +103,16 @@ spec:
             - name: CLOUD_PROVIDER_ACCESS_KEY
               valueFrom:
                 secretKeyRef:
-                  name: {{.Values.cloudprovider.secretName}}
+                  name: {{$providerCreds}}
                   key: accessKey
-              optional: true
+                  optional: true
 
             - name: CLOUD_PROVIDER_SECRET_KEY
               valueFrom:
                 secretKeyRef:
-                  name: {{.Values.cloudprovider.secretName}}
+                  name: {{$providerCreds}}
                   key: secretKey
-              optional: true
+                  optional: true
 
             - name: K3S_JOIN_TOKEN
               value: {{.Values.k3sMasters.joinToken}}
@@ -164,7 +164,7 @@ spec:
                 - ALL
       securityContext:
         runAsNonRoot: true
-      serviceAccountName: {{.Values.serviceAccount.name | squote}}
+      serviceAccountName: {{include "service-account-name" .}}
       terminationGracePeriodSeconds: 10
 {{end}}
 

--- a/charts/kloudlite-autoscalers/values.yaml
+++ b/charts/kloudlite-autoscalers/values.yaml
@@ -1,15 +1,11 @@
 # Default values for kloudlite-autoscalers.
 # This is a YAML-formatted file.
-
-replicaCount: 1
-
-clusterRegion: "ap-south-1"
-
 cloudprovider:
-  secretName: kloudlite-cloud-config
-  values:
-    accessKey: ""
-    secretKey: ""
+  # -- should be one of aws, azure, gcp, openstack, vsphere, external
+  name: "" 
+  region: ""
+  accessKey: ""
+  secretKey: ""
 
 k3sMasters:
   publicHost: ""
@@ -41,4 +37,4 @@ nodepools:
 clusterAutoscaler:
   enabled: true
   image:
-    repository: "ghcr.io/kloudlite/operators/cluster-autoscaler"
+    repository: "ghcr.io/kloudlite/operators/cluster-autoscaler-amd64"

--- a/charts/kloudlite-platform/templates/apis/infra-api.yml.tpl
+++ b/charts/kloudlite-platform/templates/apis/infra-api.yml.tpl
@@ -115,22 +115,28 @@ spec:
         - key: VPN_DEVICES_OFFSET_START
           value: {{.Values.apps.consoleApi.configuration.vpnDevicesOffsetStart | squote}}
       
-        - key: AWS_ASSUME_TENANT_ROLE_FORMAT_STRING
-          value: {{.Values.apps.infraApi.configuration.aws.tenantRoleFormatString}}
-        
         - key: AWS_ACCESS_KEY
           value: {{.Values.apps.infraApi.configuration.aws.accessKey}}
 
         - key: AWS_SECRET_KEY
           value: {{.Values.apps.infraApi.configuration.aws.secretKey}}
 
-        - key: AWS_CLOUDFORMATION_STACK_NAME_PREFIX
-          value: {{.Values.apps.infraApi.configuration.aws.cloudformation.stackNamePrefix}}
-
-        - key: AWS_CLOUDFORMATION_STACK_S3_URL
+        - key: AWS_CF_STACK_S3_URL
           value: {{.Values.apps.infraApi.configuration.aws.cloudformation.stackS3URL}}
 
-        - key: AWS_CLOUDFORMATION_PARAM_TRUSTED_ARN
+        - key: AWS_CF_PARAM_TRUSTED_ARN
           value: {{.Values.apps.infraApi.configuration.aws.cloudformation.params.trustedARN}}
+        
+        - key: AWS_CF_STACK_NAME_PREFIX
+          value: "kloudlite-access-stack"
+
+        - key: AWS_CF_ROLE_NAME_PREFIX
+          value: "kloudlite-access-role"
+
+        - key: AWS_CF_INSTANCE_PROFILE_NAME_PREFIX
+          value: "kloudlite-instance-profile"
+
+        - key: PUBLIC_DNS_HOST_SUFFIX
+          value: {{.Values.baseDomain}}
 
 


### PR DESCRIPTION
- fixes optional cloud provider accessKey, and secretKey envs, which are applicable in AWS context for instances running with IAMInstanceProfile Roles
