### PR TITLE
fix(kloudlite-autoscalers): fixes cluster autoscaler deployment flags

### DIFF
--- a/charts/kloudlite-autoscalers/templates/cluster-autoscaler/deployment.yml.tpl
+++ b/charts/kloudlite-autoscalers/templates/cluster-autoscaler/deployment.yml.tpl
@@ -25,16 +25,19 @@ spec:
 
       tolerations: {{.Values.clusterAutoscaler.tolerations | default list | toYaml | nindent 8}}
       nodeSelector: {{.Values.clusterAutoscaler.nodeSelector | default dict | toYaml | nindent 8}}
-
       containers:
-        - command:
-            - /cluster-autoscaler
-          args:
-            - --cloud-provider=kloudlite
-            - --logtostderr=true
-            - --stderrthreshold=info
-            - scale-down-unneeded-time=10m
-          image: {{.Values.clusterAutoscaler.image.repository}}:{{.Values.clusterAutoscaler.image.tag | default .Values.defaults.imageTag  | default .Chart.AppVersion }}
+        - args:
+            - --cloud-provider
+            - kloudlite
+            - --logtostderr
+            - true
+            - --stderrthreshold
+            - info
+            - --scale-down-unneeded-time
+            - {{.Values.clusterAutoscaler.configuration.scaleDownUnneededTime}}
+            - --enforce-node-group-min-size 
+            - true
+          image: {{.Values.clusterAutoscaler.image.repository}}:{{.Values.clusterAutoscaler.image.tag | default .Values.defaults.imageTag | default .Chart.AppVersion }}
           imagePullPolicy: {{.Values.clusterAutoscaler.image.pullPolicy | default .Values.defaults.imagePullPolicy }}
           name: main
           securityContext:
@@ -58,6 +61,6 @@ spec:
             requests:
               cpu: 200m
               memory: 200Mi
-      serviceAccountName: {{.Release.Name}}-{{.Values.serviceAccount.nameSuffix}}
+      serviceAccountName: {{ include "service-account-name" . }}
       terminationGracePeriodSeconds: 10
 {{- end }}

--- a/charts/kloudlite-autoscalers/values.yaml
+++ b/charts/kloudlite-autoscalers/values.yaml
@@ -12,5 +12,8 @@ clusterAutoscaler:
   enabled: true
   image:
     repository: "ghcr.io/kloudlite/cluster-autoscaler-amd64"
+    tag: kloudlite-v1.0.5-nightly
   nodeSelector: {}
   tolerations: []
+  configuration:
+    scaleDownUnneededTime: 1m


### PR DESCRIPTION
- scale down unneeded time is now configurable via chart values
- CA, now upscales to min node count defined in nodepool