### PR TITLE
fix(charts/platform): fixes nats subject template, for vector aggreagator

### DIFF
--- a/charts/kloudlite-platform/files/nats-logs-sink-subject.txt
+++ b/charts/kloudlite-platform/files/nats-logs-sink-subject.txt
@@ -1,4 +1,5 @@
 logs.
 {{- printf "{{kubernetes.pod_annotations.\"%s\"}}" "kloudlite.io/observability.account.name" -}}.
 {{- printf "{{kubernetes.pod_annotations.\"%s\"}}" "kloudlite.io/observability.cluster.name" -}}.
-{{- printf "{{kubernetes.pod_annotations.\"%s\"}}" "kloudlite.io/observability.tracking.id" }}
+{{- printf "{{kubernetes.pod_annotations.\"%s\"}}" "kloudlite.io/observability.tracking.id" -}}.
+{{- printf "{{kubernetes.container_name}}" }}

--- a/charts/kloudlite-platform/templates/0-kubernetes/cert-manager/cf-wildcard-cert.yml.tpl
+++ b/charts/kloudlite-platform/templates/0-kubernetes/cert-manager/cf-wildcard-cert.yml.tpl
@@ -19,7 +19,9 @@ spec:
     {{range $v := .Values.cloudflareWildCardCert.domains}}
     - {{$v | squote}}
     {{end}}
+    {{ if .Values.global.routerDomain }}
     - '*.{{include "router-domain" .}}'
+    {{ end }}
   secretName: kl-cert-wildcard-tls
   issuerRef:
     name: {{.Values.certManager.certIssuer.name}}

--- a/charts/kloudlite-platform/templates/0-kubernetes/cert-manager/cluster-issuer.yml.tpl
+++ b/charts/kloudlite-platform/templates/0-kubernetes/cert-manager/cluster-issuer.yml.tpl
@@ -23,7 +23,9 @@ spec:
             {{- range $v := .Values.cloudflareWildCardCert.domains}}
             - {{$v | squote}}
             {{- end }}
+            {{- if .Values.global.routerDomain }}
             - "*.{{.Values.global.routerDomain}}"
+            {{- end }}
       {{- end}}
       {{- $ingClass := .Values.global.ingressClassName }}
       {{- if $ingClass }}

--- a/charts/kloudlite-platform/templates/1-operators/platform-operator/helpers/_cluster-operator-env.yml.tpl
+++ b/charts/kloudlite-platform/templates/1-operators/platform-operator/helpers/_cluster-operator-env.yml.tpl
@@ -53,7 +53,7 @@ data:
   value: {{ required ".Values.operators.platformOperator.configuration.cluster.IACStateStore.s3BucketDir must be set" .Values.operators.platformOperator.configuration.cluster.IACStateStore.s3BucketDir }} 
 
 - name: MESSAGE_OFFICE_GRPC_ADDR
-  value: "message-office.{{.Values.global.baseDomain}}:443"
+  value: message-office.{{include "router-domain" .}}:443
 
 - name: KL_AWS_ACCESS_KEY
   value: {{ required ".Values.aws.accessKey" .Values.aws.accessKey }} 

--- a/charts/kloudlite-platform/templates/1-operators/platform-operator/helpers/_wg-operator-env.yml.tpl
+++ b/charts/kloudlite-platform/templates/1-operators/platform-operator/helpers/_wg-operator-env.yml.tpl
@@ -9,7 +9,7 @@
   value: {{.Values.operators.wgOperator.configuration.svcCIDR}}
 
 - name: DNS_HOSTED_ZONE
-  value: {{.Values.operators.wgOperator.configuration.dnsHostedZone}}
+  value: {{.Values.global.baseDomain}}
 
 - name: CLUSTER_INTERNAL_DNS
   value: {{.Values.global.clusterInternalDNS}}

--- a/charts/kloudlite-platform/templates/2-backing-services/helm-vector-aggregator.yml.tpl
+++ b/charts/kloudlite-platform/templates/2-backing-services/helm-vector-aggregator.yml.tpl
@@ -40,8 +40,7 @@ spec:
           {{- /* subject: {{ range .Files.Get "files/nats-logs-sink-subject.txt" | nindent 13 | trim | splitList "\n" }} */}}
           {{- /*   {{- . | trim -}} */}}
           {{- /*   {{ end}} */}}
-          subject: |+
-            {{ range .Files.Lines "files/nats-logs-sink-subject.txt" }} 
+          subject: {{ range .Files.Lines "files/nats-logs-sink-subject.txt" }} 
             {{- . | trim -}}
             {{ end }}
           url: {{.Values.envVars.nats.url}}
@@ -59,21 +58,21 @@ spec:
           address: 0.0.0.0:9090
           flush_period_secs: 20
 
-        loki:
-          type: loki
-          inputs:
-            - vector
-          endpoint: http://{{.Values.loki.name}}.{{.Release.Namespace}}:3100
-          encoding:
-            codec: json
-            only_fields:
-              - message
-              - timestamp
-            timestamp_format: rfc3339
-          labels: 
-            {{ range .Files.Lines "files/vector-aggregation-loki-labels.yml" }}
-            {{ . -}}
-            {{ end }}
+        {{- /* loki: */}}
+        {{- /*   type: loki */}}
+        {{- /*   inputs: */}}
+        {{- /*     - vector */}}
+        {{- /*   endpoint: http://{{.Values.loki.name}}.{{.Release.Namespace}}:3100 */}}
+        {{- /*   encoding: */}}
+        {{- /*     codec: json */}}
+        {{- /*     only_fields: */}}
+        {{- /*       - message */}}
+        {{- /*       - timestamp */}}
+        {{- /*     timestamp_format: rfc3339 */}}
+        {{- /*   labels:  */}}
+        {{- /*     {{ range .Files.Lines "files/vector-aggregation-loki-labels.yml" }} */}}
+        {{- /*     {{ . -}} */}}
+        {{- /*     {{ end }} */}}
         stdout:
           type: console
           inputs: [vector]

--- a/charts/kloudlite-platform/templates/2-backing-services/setup-jobs/nats-setup.yaml.tpl
+++ b/charts/kloudlite-platform/templates/2-backing-services/setup-jobs/nats-setup.yaml.tpl
@@ -14,15 +14,24 @@ spec:
         command: ["sh"]
         args:
          - -c
-         - |
-            echo "creatings NATS KVs"
-            {{- range $k,$bucket := .Values.envVars.nats.buckets }}
-            nats --server nats://nats:4222 kv add {{ $bucket.name }} {{- if $.Values.nats.runAsCluster}}  --replicas={{$.Values.nats.replicas}} {{- end }} --storage={{$bucket.storage}}
-            {{- end }}
+         - |+
+           echo "creatings NATS KVs"
+           {{- range $k,$bucket := .Values.envVars.nats.buckets }}
+           nats --server nats://nats:4222 kv add {{ $bucket.name }} {{- if $.Values.nats.runAsCluster}}  --replicas={{$.Values.nats.replicas}} {{- end }} --storage={{$bucket.storage}}
+           {{- end }}
 
-            echo "creatings NATS STREAMs"
-            {{- range $k,$stream := .Values.envVars.nats.streams }}
-            nats --server nats://nats:4222 stream add {{ $stream.name }} --replicas={{$.Values.nats.replicas}} --subjects={{ $stream.subjects | squote }} --max-msg-size={{ $stream.maxMsgBytes }} --storage=file {{ if $stream.maxAge }} --max-age={{$stream.maxAge}} {{ end }} --defaults
-            {{- end }}
+           echo "creatings NATS STREAMs"
+           {{- range $k,$stream := .Values.envVars.nats.streams }}
+           nats --server nats://nats:4222 stream add {{ $stream.name }} \
+             --replicas={{$.Values.nats.replicas}} \
+             --subjects={{ $stream.subjects | squote }} \
+             --max-msg-size={{ $stream.maxMsgBytes }} \
+             {{if $stream.maxMsgsPerSubject }} --max-msgs-per-subject={{$stream.maxMsgsPerSubject}} {{end}} \
+             --storage=file \
+             {{ if $stream.maxAge }} --max-age={{$stream.maxAge}} {{ end }} \
+             --compression=s2 \
+             --discard=old \
+             --defaults
+           {{- end }}
       restartPolicy: Never
   backoffLimit: 0

--- a/charts/kloudlite-platform/values.yaml
+++ b/charts/kloudlite-platform/values.yaml
@@ -407,16 +407,19 @@ envVars:
       events:
         name: events
         subjects: "events.>"
-        maxMsgBytes: 2MB
+        maxMsgBytes: 500kB
+        maxMsgsPerSubject: 2
       resourceSync:
         name: resource-sync
         subjects: "resource-sync.>"
-        maxMsgBytes: 2MB
+        maxMsgBytes: 500kB
+        # maxMsgsPerSubject: 2
       logs:
         name: logs
         subjects: "logs.>"
         maxMsgBytes: 2MB
         maxAge: "3h"
+        # maxMsgsPerSubject: 2
     buckets:
       sessionKVBucket:
         name: auth-session


### PR DESCRIPTION
- previous nats subject name, was having a leading `\n` at end, which caused logs from vector to getting dropped in `nats`. 
- handles missing `.Values.routerDomain`
- nats setup job improved
