### PR TITLE
fix(charts/aws-spot-termination-handler): corrects ServiceAccount

### DIFF
--- a/charts/aws-spot-termination-handler/templates/daemonset.yml.tpl
+++ b/charts/aws-spot-termination-handler/templates/daemonset.yml.tpl
@@ -15,6 +15,8 @@ spec:
     spec:
       serviceAccountName: {{.Values.name}}
       nodeSelector: {{ .Values.nodeSelector | toYaml | nindent 10 }}
+      tolerations:
+        - operator: Exists
       containers:
       - name: main
         image: {{.Values.image.name}}:{{.Values.kloudliteRelease}}

--- a/charts/aws-spot-termination-handler/templates/rbac.yml.tpl
+++ b/charts/aws-spot-termination-handler/templates/rbac.yml.tpl
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{.Values.name}}
-  namespace: kube-system
+  namespace: {{.Release.Namespace}}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -15,5 +15,5 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: {{.Values.name}}
-    namespace: kube-system
+    namespace: {{.Release.Namespace}}
 ---


### PR DESCRIPTION
fixes service account namespace in helm templates