### PR TITLE
Fix/charts

### DIFF
--- a/charts/kloudlite-agent/templates/helm-charts/cluster-autoscaler.yml.tpl
+++ b/charts/kloudlite-agent/templates/helm-charts/cluster-autoscaler.yml.tpl
@@ -8,12 +8,11 @@ metadata:
 spec:
   chartRepoURL: https://kloudlite.github.io/helm-charts
   chartName: "kloudlite-autoscalers"
-  chartVersion: {{ include "image-tag" .}}
+  chartVersion: {{ .Values.helmCharts.clusterAutoscaler.configuration.chartVersion | default (include "image-tag" .)}}
   jobVars:
     tolerations:
       - operator: Exists
   values:
-    kloudliteRelease: {{ include "image-tag" .}}
     clusterAutoscaler:
       enabled: true
       nodeSelector:

--- a/charts/kloudlite-agent/values.yaml
+++ b/charts/kloudlite-agent/values.yaml
@@ -38,7 +38,7 @@ agent:
   name: kl-agent
   # -- kloudlite agent image name and tag
   image: 
-    repository: ghcr.io/kloudlite/agents/kl-agent
+    repository: ghcr.io/kloudlite/api/tenant-agent
     # -- image tag for kloudlite agent, by default uses kloudlite_release
     tag: ""
     # -- image pull policy for kloudlite agent, default is .imagePullPolicy
@@ -65,6 +65,17 @@ operators:
     nodeSelector: {}
 
     configuration:
+      cloudprovider: "aws"
+      aws:
+        vpc_params:
+          readFromCluster: true
+          secret:
+            name: "kloudlite-aws-settings"
+            namespace: "kube-system"
+            keys:
+              vpcId: "vpc_id"
+              vpcPublicSubnets: "vpc_public_subnets"
+
       letsEncryptSupportEmail: "support@kloudlite.io"
       iacJobImage: 
         repository: ghcr.io/kloudlite/infrastructure-as-code/iac-job
@@ -119,3 +130,5 @@ helmCharts:
 
   clusterAutoscaler:
     enabled: true
+    configuration:
+      chartVersion: ""

--- a/charts/kloudlite-platform/templates/0-kubernetes/nodepools/iac.yml.tpl
+++ b/charts/kloudlite-platform/templates/0-kubernetes/nodepools/iac.yml.tpl
@@ -1,10 +1,11 @@
+{{- if .Values.nodepools.iac.enabled }}
 apiVersion: clusters.kloudlite.io/v1
 kind: NodePool
 metadata:
   name: iac
 spec:
-  minCount: 2
-  maxCount: 10
+  minCount: {{.Values.nodepools.iac.min}}
+  maxCount: {{.Values.nodepools.iac.max}}
 
   nodeTaints: {{.Values.nodepools.iac.taints | toYaml | nindent 4}}
   nodeLabels: {{.Values.nodepools.iac.labels | toYaml | nindent 4}}
@@ -28,3 +29,4 @@ spec:
         memoryPerVcpu:
           min: "2"
           max: "2"
+{{- end }}

--- a/charts/kloudlite-platform/templates/0-kubernetes/nodepools/stateful.yml.tpl
+++ b/charts/kloudlite-platform/templates/0-kubernetes/nodepools/stateful.yml.tpl
@@ -3,8 +3,8 @@ kind: NodePool
 metadata:
   name: stateful
 spec:
-  minCount: 3
-  maxCount: 3
+  minCount: {{.Values.nodepools.stateful.min}}
+  maxCount: {{.Values.nodepools.stateful.max}}
 
   nodeTaints: {{.Values.nodepools.stateful.taints | toYaml | nindent 4}}
   nodeLabels: {{.Values.nodepools.stateful.labels | toYaml | nindent 4}}

--- a/charts/kloudlite-platform/templates/0-kubernetes/nodepools/stateless.yml.tpl
+++ b/charts/kloudlite-platform/templates/0-kubernetes/nodepools/stateless.yml.tpl
@@ -3,8 +3,8 @@ kind: NodePool
 metadata:
   name: stateless
 spec:
-  minCount: 2
-  maxCount: 2
+  minCount: {{.Values.nodepools.stateless.min }}
+  maxCount: {{.Values.nodepools.stateless.max }}
 
   nodeTaints: {{.Values.nodepools.stateless.taints | toYaml | nindent 4}}
   nodeLabels: {{.Values.nodepools.stateless.labels | toYaml | nindent 4}}

--- a/charts/kloudlite-platform/templates/1-operators/platform-operator/helpers/_cluster-operator-env.yml.tpl
+++ b/charts/kloudlite-platform/templates/1-operators/platform-operator/helpers/_cluster-operator-env.yml.tpl
@@ -53,9 +53,9 @@ data:
   value: {{.Values.operators.platformOperator.configuration.cluster.jobImage.repository}}:{{.Values.operators.platformOperator.configuration.cluster.jobImage.tag | default (include "image-tag" .) }}
 
 - name: "IAC_JOB_TOLERATIONS"
-  value: '[{"key":"kloudlite.io/nodepool.role","value":"iac","effect":"NoExecute"}]'
+  value: {{.Values.nodepools.iac.tolerations | toJson | squote}}
 
 - name: IAC_JOB_NODE_SELECTOR
-  value: '{"kloudlite.io/nodepool.role": "iac"}'
+  value: {{.Values.nodepools.iac.labels | toJson |squote}}
 
 {{- end -}}

--- a/charts/kloudlite-platform/templates/2-backing-services/helm-nats.yml.tpl
+++ b/charts/kloudlite-platform/templates/2-backing-services/helm-nats.yml.tpl
@@ -11,8 +11,8 @@ spec:
   chartName: nats
   chartVersion: 1.1.5
   jobVars:
-    tolerations:
-      - operator: Exists
+    tolerations: {{.Values.nodepools.stateful.tolerations | toYaml | nindent 6 }}
+    nodeSelector: {{.Values.nodepools.stateful.labels | toYaml | nindent 6 }}
   values:
     global:
       labels:
@@ -21,6 +21,7 @@ spec:
     fullnameOverride: {{$chartName}}
     namespaceOverride: {{.Release.Namespace}}
 
+    {{- if .Values.nats.runAsCluster }}
     container:
       env:
         # different from k8s units, suffix must be B, KiB, MiB, GiB, or TiB
@@ -35,6 +36,7 @@ spec:
           limits:
             cpu: "1"
             memory: 3Gi
+    {{- end }}
 
     config:
       cluster:
@@ -68,12 +70,12 @@ spec:
             tolerations: {{.Values.nodepools.stateful.tolerations | toYaml | nindent 12 }}
             nodeSelector: {{.Values.nodepools.stateful.labels | toYaml | nindent 12 }}
 
-{{- if .Values.nats.runAsCluster}}
     podTemplate:
       merge:
         spec:
           tolerations: {{.Values.nodepools.stateful.tolerations | toYaml | nindent 12}}
           nodeSelector: {{.Values.nodepools.stateful.labels | toYaml | nindent 12}}
+{{- if .Values.nats.runAsCluster}}
       topologySpreadConstraints:
         kloudlite.io/provider.az:
           maxSkew: 1

--- a/charts/kloudlite-platform/templates/3-apps/apis/apps/infra-api.yml.tpl
+++ b/charts/kloudlite-platform/templates/3-apps/apis/apps/infra-api.yml.tpl
@@ -83,7 +83,7 @@ spec:
           value: message-office.{{include "router-domain" . }}:443
 
         - key: KLOUDLITE_RELEASE
-          value: {{.Values.global.kloudlite_release}}
+          value: {{.Values.apps.infraApi.configuration.kloudliteRelease | default .Values.global.kloudlite_release}}
 
         - key: AWS_ACCESS_KEY
           value: {{.Values.aws.accessKey}}

--- a/charts/kloudlite-platform/values.yaml
+++ b/charts/kloudlite-platform/values.yaml
@@ -81,6 +81,8 @@ ingressController:
 
 nodepools:
   stateless:
+    min: 2
+    max: 2
     labels:
       kloudlite.io/nodepool.role: "stateless"
     taints:
@@ -94,6 +96,8 @@ nodepools:
         effect: "NoExecute"
 
   stateful:
+    min: 2
+    max: 2
     labels:
       kloudlite.io/nodepool.role: "stateful"
     taints:
@@ -106,6 +110,9 @@ nodepools:
         value: "stateful"
         effect: "NoExecute"
   iac:
+    enabled: true
+    min: 2
+    max: 10
     labels:
       kloudlite.io/nodepool.role: "iac"
     taints:
@@ -358,6 +365,9 @@ apps:
     image:
       repository: ghcr.io/kloudlite/api/infra
       tag: ""
+
+    configuration:
+      kloudliteRelease: ""
 
   gatewayApi:
     image:


### PR DESCRIPTION
- agent operator `cluster-autoscaler` chart version, and auto load AWS VPC settings
- controlling nodepools min/max size from helm values in `charts/kloudlite-platform`