### PR TITLE
feat/nats-and-mongo-backup-cron

### DIFF
--- a/charts/kloudlite-platform/templates/4-cron-jobs/mongo-backup/cron.yml.tpl
+++ b/charts/kloudlite-platform/templates/4-cron-jobs/mongo-backup/cron.yml.tpl
@@ -21,7 +21,7 @@ spec:
                 - /bin/sh
                 - -c
                 - |
-                  apk add zip
+                  apt update && apt install zip -y
                   set -o errexit
                   set -o pipefail
 

--- a/charts/kloudlite-platform/templates/4-cron-jobs/mongo-backup/pvc.yml.tpl
+++ b/charts/kloudlite-platform/templates/4-cron-jobs/mongo-backup/pvc.yml.tpl
@@ -1,0 +1,14 @@
+{{- $cronName := "mongo-csi-s3-backup" }}
+
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{$cronName}}
+  namespace: {{.Release.Namespace}}
+spec:
+  accessModes:
+  - ReadWriteMany
+  resources:
+    requests:
+      storage: 200Gi
+  storageClassName: {{$cronName}}

--- a/charts/kloudlite-platform/templates/4-cron-jobs/mongo-backup/secret.yml.tpl
+++ b/charts/kloudlite-platform/templates/4-cron-jobs/mongo-backup/secret.yml.tpl
@@ -1,0 +1,11 @@
+{{- $cronSecretName := "mongo-csi-s3-secret" }}
+
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{$cronSecretName}}
+  namespace: {{.Release.Namespace}}
+stringData:
+  accessKeyID: {{.Values.crons.mongoBackup.s3.accessKeyId}}
+  secretAccessKey: {{.Values.crons.mongoBackup.s3.secretKey}}
+  endpoint: {{.Values.crons.mongoBackup.s3.endpoint}}

--- a/charts/kloudlite-platform/templates/4-cron-jobs/mongo-backup/storage-class.yml.tpl
+++ b/charts/kloudlite-platform/templates/4-cron-jobs/mongo-backup/storage-class.yml.tpl
@@ -13,12 +13,12 @@ parameters:
   options: "--memory-limit 1000 --dir-mode 0777 --file-mode 0666"
   # to use an existing bucket, specify it here:
   #bucket: some-existing-bucket
-  csi.storage.k8s.io/provisioner-secret-name: {{$cronSecretName}}
+  csi.storage.k8s.io/provisioner-secret-name: {{ $cronSecretName }}
   csi.storage.k8s.io/provisioner-secret-namespace: {{ $ns }}
-  csi.storage.k8s.io/controller-publish-secret-name: {{$cronSecretName}}
+  csi.storage.k8s.io/controller-publish-secret-name: {{ $cronSecretName }}
   csi.storage.k8s.io/controller-publish-secret-namespace: {{ $ns }}
-  csi.storage.k8s.io/node-stage-secret-name: {{$cronSecretName}}
+  csi.storage.k8s.io/node-stage-secret-name: {{ $cronSecretName }}
   csi.storage.k8s.io/node-stage-secret-namespace: {{ $ns }}
-  csi.storage.k8s.io/node-publish-secret-name: {{$cronSecretName}}
+  csi.storage.k8s.io/node-publish-secret-name: {{ $cronSecretName }}
   csi.storage.k8s.io/node-publish-secret-namespace: {{ $ns }}
   bucket: {{.Values.crons.mongoBackup.configuration.bucket}}

--- a/charts/kloudlite-platform/templates/4-cron-jobs/mongo-backup/storage-class.yml.tpl
+++ b/charts/kloudlite-platform/templates/4-cron-jobs/mongo-backup/storage-class.yml.tpl
@@ -1,0 +1,24 @@
+{{- $cronName := "mongo-csi-s3-backup" }}
+{{- $cronSecretName := "mongo-csi-s3-secret" }}
+{{- $ns := .Release.Namespace }}
+
+kind: StorageClass
+apiVersion: storage.k8s.io/v1
+metadata:
+  name: {{$cronName}}
+provisioner: ru.yandex.s3.csi
+parameters:
+  mounter: geesefs
+  # you can set mount options here, for example limit memory cache size (recommended)
+  options: "--memory-limit 1000 --dir-mode 0777 --file-mode 0666"
+  # to use an existing bucket, specify it here:
+  #bucket: some-existing-bucket
+  csi.storage.k8s.io/provisioner-secret-name: {{$cronSecretName}}
+  csi.storage.k8s.io/provisioner-secret-namespace: {{ $ns }}
+  csi.storage.k8s.io/controller-publish-secret-name: {{$cronSecretName}}
+  csi.storage.k8s.io/controller-publish-secret-namespace: {{ $ns }}
+  csi.storage.k8s.io/node-stage-secret-name: {{$cronSecretName}}
+  csi.storage.k8s.io/node-stage-secret-namespace: {{ $ns }}
+  csi.storage.k8s.io/node-publish-secret-name: {{$cronSecretName}}
+  csi.storage.k8s.io/node-publish-secret-namespace: {{ $ns }}
+  bucket: {{.Values.crons.mongoBackup.configuration.bucket}}

--- a/charts/kloudlite-platform/templates/4-cron-jobs/nats-backup/cron.yml.tpl
+++ b/charts/kloudlite-platform/templates/4-cron-jobs/nats-backup/cron.yml.tpl
@@ -1,0 +1,71 @@
+{{- $cronName := "nats-csi-s3-backup" }}
+
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: {{$cronName}}
+  namespace: {{.Release.Namespace}}
+spec:
+  schedule: "{{.Values.crons.natsBackup.configuration.schedule}}"
+  jobTemplate:
+    spec:
+      template:
+        metadata:
+          labels:
+            app: {{$cronName}}
+        spec:
+          containers:
+            - name: {{$cronName}}
+              image: {{.Values.crons.natsBackup.configuration.image}}
+              command: 
+                - /bin/sh
+                - -c
+                - |
+                  apk add zip
+                  set -o errexit
+                  set -o pipefail
+
+                  trap 'echo "Backup failed"; exit 1' ERR
+
+                  BACKUP_DEST="/nats-backups"
+
+                  TIMESTAMP=$(date +"%Y%m%d%H%M%S")
+                  FILENAME="backup_${TIMESTAMP}"
+                  BACKUP_DIR="${BACKUP_DEST}/${FILENAME}.zip"
+
+                  BACKUP_TEMP_DIR="/tmp/${FILENAME}"
+
+                  mkdir -p "$BACKUP_DEST"
+                  nats account backup --server  $NATS_SERVER "$BACKUP_TEMP_DIR" -f
+
+                  zip -r -P "$ENCRYPTION_PASSWORD" "${BACKUP_TEMP_DIR}.zip" "$BACKUP_TEMP_DIR"
+
+                  cp "${BACKUP_TEMP_DIR}.zip" "$BACKUP_DIR"
+
+                  cd "$BACKUP_DEST" || exit
+                  BACKUPS=$(ls -1t)
+
+                  COUNT=0
+                  for BACKUP in $BACKUPS; do
+                    echo "Processing backup $BACKUP"
+                    COUNT=$((COUNT + 1))
+                    if [ "$COUNT" -gt "$NUM_BACKUPS" ]; then
+                      rm -rf "$BACKUP"
+                    fi
+                  done
+
+                  echo "Backup completed"
+              env:
+                - name: NATS_SERVER
+                  value: {{.Values.crons.natsBackup.configuration.server}}
+                - name: NUM_BACKUPS
+                  value: {{.Values.crons.natsBackup.configuration.numBackups | default "5"}}
+              volumeMounts:
+                - mountPath: /nats-backups
+                  name: nats-backups
+          restartPolicy: OnFailure
+          volumes:
+            - name: nats-backups
+              persistentVolumeClaim:
+                claimName: {{$cronName}}
+                readOnly: false

--- a/charts/kloudlite-platform/templates/4-cron-jobs/nats-backup/pvc.yml.tpl
+++ b/charts/kloudlite-platform/templates/4-cron-jobs/nats-backup/pvc.yml.tpl
@@ -1,0 +1,14 @@
+{{- $cronName := "nats-csi-s3-backup" }}
+
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{$cronName}}
+  namespace: {{.Release.Namespace}}
+spec:
+  accessModes:
+  - ReadWriteMany
+  resources:
+    requests:
+      storage: 200Gi
+  storageClassName: {{$cronName}}

--- a/charts/kloudlite-platform/templates/4-cron-jobs/nats-backup/secret.yml.tpl
+++ b/charts/kloudlite-platform/templates/4-cron-jobs/nats-backup/secret.yml.tpl
@@ -1,0 +1,11 @@
+{{- $cronSecretName := "nats-csi-s3-secret" }}
+
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{$cronSecretName}}
+  namespace: {{.Release.Namespace}}
+stringData:
+  accessKeyID: {{.Values.crons.natsBackup.s3.accessKeyId}}
+  secretAccessKey: {{.Values.crons.natsBackup.s3.secretKey}}
+  endpoint: {{.Values.crons.natsBackup.s3.endpoint}}

--- a/charts/kloudlite-platform/templates/4-cron-jobs/nats-backup/storage-class.yml.tpl
+++ b/charts/kloudlite-platform/templates/4-cron-jobs/nats-backup/storage-class.yml.tpl
@@ -13,12 +13,12 @@ parameters:
   options: "--memory-limit 1000 --dir-mode 0777 --file-mode 0666"
   # to use an existing bucket, specify it here:
   #bucket: some-existing-bucket
-  csi.storage.k8s.io/provisioner-secret-name: {{$cronSecretName}}
+  csi.storage.k8s.io/provisioner-secret-name: {{ $cronSecretName }}
   csi.storage.k8s.io/provisioner-secret-namespace: {{ $ns }}
-  csi.storage.k8s.io/controller-publish-secret-name: {{$cronSecretName}}
+  csi.storage.k8s.io/controller-publish-secret-name: {{ $cronSecretName }}
   csi.storage.k8s.io/controller-publish-secret-namespace: {{ $ns }}
-  csi.storage.k8s.io/node-stage-secret-name: {{$cronSecretName}}
+  csi.storage.k8s.io/node-stage-secret-name: {{ $cronSecretName }}
   csi.storage.k8s.io/node-stage-secret-namespace: {{ $ns }}
-  csi.storage.k8s.io/node-publish-secret-name: {{$cronSecretName}}
+  csi.storage.k8s.io/node-publish-secret-name: {{ $cronSecretName }}
   csi.storage.k8s.io/node-publish-secret-namespace: {{ $ns }}
   bucket: {{.Values.crons.natsBackup.configuration.bucket}}

--- a/charts/kloudlite-platform/templates/4-cron-jobs/nats-backup/storage-class.yml.tpl
+++ b/charts/kloudlite-platform/templates/4-cron-jobs/nats-backup/storage-class.yml.tpl
@@ -1,0 +1,24 @@
+{{- $cronName := "nats-csi-s3-backup" }}
+{{- $cronSecretName := "nats-csi-s3-secret" }}
+{{- $ns := .Release.Namespace }}
+
+kind: StorageClass
+apiVersion: storage.k8s.io/v1
+metadata:
+  name: {{$cronName}}
+provisioner: ru.yandex.s3.csi
+parameters:
+  mounter: geesefs
+  # you can set mount options here, for example limit memory cache size (recommended)
+  options: "--memory-limit 1000 --dir-mode 0777 --file-mode 0666"
+  # to use an existing bucket, specify it here:
+  #bucket: some-existing-bucket
+  csi.storage.k8s.io/provisioner-secret-name: {{$cronSecretName}}
+  csi.storage.k8s.io/provisioner-secret-namespace: {{ $ns }}
+  csi.storage.k8s.io/controller-publish-secret-name: {{$cronSecretName}}
+  csi.storage.k8s.io/controller-publish-secret-namespace: {{ $ns }}
+  csi.storage.k8s.io/node-stage-secret-name: {{$cronSecretName}}
+  csi.storage.k8s.io/node-stage-secret-namespace: {{ $ns }}
+  csi.storage.k8s.io/node-publish-secret-name: {{$cronSecretName}}
+  csi.storage.k8s.io/node-publish-secret-namespace: {{ $ns }}
+  bucket: {{.Values.crons.natsBackup.configuration.bucket}}

--- a/charts/kloudlite-platform/templates/utils/csi-s3/csi-s3.yaml
+++ b/charts/kloudlite-platform/templates/utils/csi-s3/csi-s3.yaml
@@ -1,0 +1,124 @@
+{{- $ns := .Release.Namespace }}
+
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: csi-s3
+  namespace: {{ $ns }}
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: csi-s3
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: csi-s3
+subjects:
+  - kind: ServiceAccount
+    name: csi-s3
+    namespace: {{ $ns }}
+roleRef:
+  kind: ClusterRole
+  name: csi-s3
+  apiGroup: rbac.authorization.k8s.io
+---
+kind: DaemonSet
+apiVersion: apps/v1
+metadata:
+  name: csi-s3
+  namespace: {{ $ns }}
+spec:
+  selector:
+    matchLabels:
+      app: csi-s3
+  template:
+    metadata:
+      labels:
+        app: csi-s3
+    spec:
+      tolerations:
+        - key: CriticalAddonsOnly
+          operator: Exists
+        - operator: Exists
+          effect: NoExecute
+          tolerationSeconds: 300
+      serviceAccount: csi-s3
+      containers:
+        - name: driver-registrar
+          image: quay.io/k8scsi/csi-node-driver-registrar:v1.2.0
+          args:
+            - "--kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)"
+            - "--v=4"
+            - "--csi-address=$(ADDRESS)"
+          env:
+            - name: ADDRESS
+              value: /csi/csi.sock
+            - name: DRIVER_REG_SOCK_PATH
+              value: /var/lib/kubelet/plugins/ru.yandex.s3.csi/csi.sock
+            - name: KUBE_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+          volumeMounts:
+            - name: plugin-dir
+              mountPath: /csi
+            - name: registration-dir
+              mountPath: /registration/
+        - name: csi-s3
+          securityContext:
+            privileged: true
+            capabilities:
+              add: ["SYS_ADMIN"]
+            allowPrivilegeEscalation: true
+          image: cr.yandex/crp9ftr22d26age3hulg/csi-s3:0.41.1
+          imagePullPolicy: IfNotPresent
+          args:
+            - "--endpoint=$(CSI_ENDPOINT)"
+            - "--nodeid=$(NODE_ID)"
+            - "--v=4"
+          env:
+            - name: CSI_ENDPOINT
+              value: unix:///csi/csi.sock
+            - name: NODE_ID
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+          volumeMounts:
+            - name: plugin-dir
+              mountPath: /csi
+            - name: stage-dir
+              mountPath: /var/lib/kubelet/plugins/kubernetes.io/csi
+              mountPropagation: "Bidirectional"
+            - name: pods-mount-dir
+              mountPath: /var/lib/kubelet/pods
+              mountPropagation: "Bidirectional"
+            - name: fuse-device
+              mountPath: /dev/fuse
+            - name: systemd-control
+              mountPath: /run/systemd
+      volumes:
+        - name: registration-dir
+          hostPath:
+            path: /var/lib/kubelet/plugins_registry/
+            type: DirectoryOrCreate
+        - name: plugin-dir
+          hostPath:
+            path: /var/lib/kubelet/plugins/ru.yandex.s3.csi
+            type: DirectoryOrCreate
+        - name: stage-dir
+          hostPath:
+            path: /var/lib/kubelet/plugins/kubernetes.io/csi
+            type: DirectoryOrCreate
+        - name: pods-mount-dir
+          hostPath:
+            path: /var/lib/kubelet/pods
+            type: Directory
+        - name: fuse-device
+          hostPath:
+            path: /dev/fuse
+        - name: systemd-control
+          hostPath:
+            path: /run/systemd
+            type: DirectoryOrCreate

--- a/charts/kloudlite-platform/templates/utils/csi-s3/driver.yaml
+++ b/charts/kloudlite-platform/templates/utils/csi-s3/driver.yaml
@@ -1,0 +1,7 @@
+apiVersion: storage.k8s.io/v1
+kind: CSIDriver
+metadata:
+  name: ru.yandex.s3.csi
+spec:
+  attachRequired: false
+  podInfoOnMount: true

--- a/charts/kloudlite-platform/templates/utils/csi-s3/provisioner.yaml
+++ b/charts/kloudlite-platform/templates/utils/csi-s3/provisioner.yaml
@@ -1,0 +1,111 @@
+{{- $ns := .Release.Namespace }}
+
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: csi-s3-provisioner-sa
+  namespace: {{ $ns }}
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: csi-s3-external-provisioner-runner
+rules:
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "list"]
+  - apiGroups: [""]
+    resources: ["persistentvolumes"]
+    verbs: ["get", "list", "watch", "create", "delete"]
+  - apiGroups: [""]
+    resources: ["persistentvolumeclaims"]
+    verbs: ["get", "list", "watch", "update"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["storageclasses"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["list", "watch", "create", "update", "patch"]
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: csi-s3-provisioner-role
+subjects:
+  - kind: ServiceAccount
+    name: csi-s3-provisioner-sa
+    namespace: {{ $ns }}
+roleRef:
+  kind: ClusterRole
+  name: csi-s3-external-provisioner-runner
+  apiGroup: rbac.authorization.k8s.io
+---
+kind: Service
+apiVersion: v1
+metadata:
+  name: csi-s3-provisioner
+  namespace: {{ $ns }}
+  labels:
+    app: csi-s3-provisioner
+spec:
+  selector:
+    app: csi-s3-provisioner
+  ports:
+    - name: csi-s3-dummy
+      port: 65535
+---
+kind: StatefulSet
+apiVersion: apps/v1
+metadata:
+  name: csi-s3-provisioner
+  namespace: {{ $ns }}
+spec:
+  serviceName: "csi-provisioner-s3"
+  replicas: 1
+  selector:
+    matchLabels:
+      app: csi-s3-provisioner
+  template:
+    metadata:
+      labels:
+        app: csi-s3-provisioner
+    spec:
+      serviceAccount: csi-s3-provisioner-sa
+      tolerations:
+        - key: node-role.kubernetes.io/master
+          operator: Exists
+        - key: CriticalAddonsOnly
+          operator: Exists
+      containers:
+        - name: csi-provisioner
+          image: quay.io/k8scsi/csi-provisioner:v2.1.0
+          args:
+            - "--csi-address=$(ADDRESS)"
+            - "--v=4"
+          env:
+            - name: ADDRESS
+              value: /var/lib/kubelet/plugins/ru.yandex.s3.csi/csi.sock
+          imagePullPolicy: "IfNotPresent"
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /var/lib/kubelet/plugins/ru.yandex.s3.csi
+        - name: csi-s3
+          image: cr.yandex/crp9ftr22d26age3hulg/csi-s3:0.41.1
+          imagePullPolicy: IfNotPresent
+          args:
+            - "--endpoint=$(CSI_ENDPOINT)"
+            - "--nodeid=$(NODE_ID)"
+            - "--v=4"
+          env:
+            - name: CSI_ENDPOINT
+              value: unix:///var/lib/kubelet/plugins/ru.yandex.s3.csi/csi.sock
+            - name: NODE_ID
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /var/lib/kubelet/plugins/ru.yandex.s3.csi
+      volumes:
+        - name: socket-dir
+          emptyDir: {}

--- a/charts/kloudlite-platform/values.yaml
+++ b/charts/kloudlite-platform/values.yaml
@@ -674,7 +674,7 @@ crons:
       numBackups: 5
       schedule: "0 */2 * * *" # Runs every 2 hours
       bucket: ""
-    credentials:
+    s3:
       accessKeyId: ""
       secretKey: ""
       endpoint: ""

--- a/charts/kloudlite-platform/values.yaml
+++ b/charts/kloudlite-platform/values.yaml
@@ -665,8 +665,19 @@ envVars:
         storage: file
 
 crons:
+  mongoBackup:
+    name: mongo-backup
+    configuration:
+      image: mongo:latest
+      mongodbUri: ""
+      numBackups: 5
+      schedule: "0 */2 * * *" # Runs every 2 hours
+      encryptionPassword: ""
+    s3:
+      accessKeyId: ""
+      secretKey: ""
+      endpoint: ""
   natsBackup:
-    enabled: true
     name: nats-backup
     configuration:
       image: natsio/nats-box:latest
@@ -674,6 +685,7 @@ crons:
       numBackups: 5
       schedule: "0 */2 * * *" # Runs every 2 hours
       bucket: ""
+      encryptionPassword: ""
     s3:
       accessKeyId: ""
       secretKey: ""

--- a/charts/kloudlite-platform/values.yaml
+++ b/charts/kloudlite-platform/values.yaml
@@ -663,3 +663,18 @@ envVars:
       resetTokenBucket:
         name: reset-token
         storage: file
+
+crons:
+  natsBackup:
+    enabled: true
+    name: nats-backup
+    configuration:
+      image: natsio/nats-box:latest
+      server: ""
+      numBackups: 5
+      schedule: "0 */2 * * *" # Runs every 2 hours
+      bucket: ""
+    credentials:
+      accessKeyId: ""
+      secretKey: ""
+      endpoint: ""


### PR DESCRIPTION
- added cron for nats backup
- added cron for mongodb

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

This pull request adds a cron job for NATS backups, scheduled to run every 2 hours, and integrates S3 storage using a CSI driver. It includes the necessary configurations for RBAC, service accounts, and a new StorageClass for S3-backed persistent volumes.

- **New Features**:
    - Introduced a cron job for NATS backup, scheduled to run every 2 hours.
    - Added support for S3 storage integration for NATS backups using a CSI driver.
- **Enhancements**:
    - Configured a new CSI driver for S3 storage, including necessary RBAC roles, bindings, and service accounts.
    - Set up a new StorageClass for S3-backed persistent volumes.

<!-- Generated by sourcery-ai[bot]: end summary -->